### PR TITLE
[UI] Rounded bottom corners for GroupBox controls (on hover)

### DIFF
--- a/HedgeModManager/App.xaml
+++ b/HedgeModManager/App.xaml
@@ -234,7 +234,7 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type GroupBox}">
                         <Grid>
-                            <Border x:Name="EffectBorder" Background="#2D2D30" CornerRadius="8,8,0,0" Effect="{StaticResource HoverEffect}"/>
+                            <Border x:Name="EffectBorder" Background="#2D2D30" CornerRadius="8,8,8,8" Effect="{StaticResource HoverEffect}"/>
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />


### PR DESCRIPTION
Bottom left and bottom right corners on GroupBox controls weren't rounded like the others. This PR should fix that.