### PR TITLE
[Sonic Generations] More miscellaneous patches

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -605,3 +605,9 @@ WriteNop(0x109B8DD, 2);
 
 Patch "Disable Boost Button Prompt" by "Hyper"
 WriteProtected<byte>(0x109BC7C, 0xE9, 0x71, 0x01, 0x00, 0x00);
+
+Patch "Always Use Sphere Spindash" by "Hyper"
+WriteProtected<byte>(0x1A545A4, 0xEC, 0xAD);
+
+Patch "Always Use Ellipse Spindash" by "Hyper"
+WriteProtected<byte>(0x1289ADE, 0x14, 0xAE);

--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -606,8 +606,8 @@ WriteNop(0x109B8DD, 2);
 Patch "Disable Boost Button Prompt" by "Hyper"
 WriteProtected<byte>(0x109BC7C, 0xE9, 0x71, 0x01, 0x00, 0x00);
 
-Patch "Always Use Sphere Spindash" by "Hyper"
-WriteProtected<byte>(0x1A545A4, 0xEC, 0xAD);
-
-Patch "Always Use Ellipse Spindash" by "Hyper"
+Patch "Always Use Ellipse Spin Dash" by "Hyper"
 WriteProtected<byte>(0x1289ADE, 0x14, 0xAE);
+
+Patch "Always Use Sphere Spin Dash" by "Hyper"
+WriteProtected<byte>(0x1A545A4, 0xEC, 0xAD);

--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -580,23 +580,28 @@ Patch "Disable Spin Jump Particles" by "Hyper"
 WriteProtected<byte>(0x15E902C, 0x00);
 
 Patch "Disable Light Dash Particles" by "Hyper"
-WriteProtected<byte>(0x10538EB, 0xE9, 0x8F, 0x00, 0x00, 0x00);
-WriteNop(0x10538F0, 1);
+WriteProtected<byte>(0x10538EB, 0xE9, 0x8F, 0x00, 0x00, 0x00, 0x90);
 
 Patch "Disable Input Guides" by "Hyper"
-WriteNop(0x529046, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateBoostDive */
-WriteNop(0x529846, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateQuickStep */
-WriteNop(0x529E36, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateDirection */
-WriteNop(0x52A333, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateSliding */
+WriteNop(0x529046, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateBoostDive        */
+WriteNop(0x529846, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateQuickStep        */
+WriteNop(0x529E36, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateDirection        */
+WriteNop(0x52A333, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateSliding          */
 WriteNop(0x52A963, 7); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateCommonButtonSign */
-WriteNop(0x528E41, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateLeftRightSign */
+WriteNop(0x528E41, 6); /* Sonic::Player::Hud::Guide::CSonicHudGuide::CStateLeftRightSign    */
 
 Patch "Disable Lap Time Display" by "Hyper"
-WriteProtected<byte>(0x10976EF, 0x90, 0xE9)
+WriteProtected<byte>(0x10976EF, 0x90, 0xE9);
 
 Patch "Disable Homing Reticle" by "Hyper"
-WriteProtected<byte>(0xDEBC36, 0x00)
+WriteProtected<byte>(0xDEBC36, 0x00);
 
 Patch "Disable Spin Dash on Dash Panels" by "Hyper"
-WriteProtected<byte>(0xE0AC1C, 0xE9, 0x27, 0x01, 0x00, 0x00)
-WriteProtected<byte>(0xE0C734, 0xE9, 0x27, 0x01, 0x00, 0x00)
+WriteProtected<byte>(0xE0AC1C, 0xE9, 0x27, 0x01, 0x00, 0x00);
+WriteProtected<byte>(0xE0C734, 0xE9, 0x27, 0x01, 0x00, 0x00);
+
+Patch "Disable Boost Gauge" by "Hyper"
+WriteNop(0x109B8DD, 2);
+
+Patch "Disable Boost Button Prompt" by "Hyper"
+WriteProtected<byte>(0x109BC7C, 0xE9, 0x71, 0x01, 0x00, 0x00);

--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -611,3 +611,6 @@ WriteProtected<byte>(0x1289ADE, 0x14, 0xAE);
 
 Patch "Always Use Sphere Spin Dash" by "Hyper"
 WriteProtected<byte>(0x1A545A4, 0xEC, 0xAD);
+
+Patch "Disable Loading Hints" by "Hyper"
+WriteProtected<byte>(0x448959, 0xE9, 0x12, 0x01, 0x00, 0x00);


### PR DESCRIPTION
Additions;
- Always Use Ellipse Spin Dash - replaces the sphere spin dash animation with the ellipse one for Classic Sonic.
- Always Use Sphere Spin Dash - replaces the ellipse spin dash animation with the sphere one for Classic Sonic.
- Disable Boost Gauge - does exactly what it says, in case you want that.
- Disable Boost Button Prompt - removes the X button and 'Boost' text above the boost gauge.
- Disable Loading Hints - removes the Omochao hints and mission context from the loading screens - somehow also improves loading times a significant amount.

Miscellaneous;
- Added semi-colons to "end" the functions, despite it not being required - it just bothered me. :P
- Removed `WriteNop` for Disable Light Dash Particles and added the `0x90` as a byte instead, since it was literally the next byte in the sequence anyway.