### PR TITLE
[Sonic Generations] Add 'Disable Boost Particles' patch

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -747,3 +747,7 @@ WriteNop(0x00DC50DF, 6)
 
 Patch "Red Rings Appear On New Game" by "brianuuu"
 WriteNop(0x11A9ECB, 2);
+
+Patch "Disable Boost Particles" by "Hyper"
+WriteProtected<byte>(0x15E9048, 0x00);
+WriteProtected<byte>(0x15E9060, 0x00);


### PR DESCRIPTION
The SEGA logo messed up the boost particles and removed them entirely and I kinda liked it, so here we are.