### PR TITLE
[Sonic Generations] Update particle codes for Super Sonic

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -775,3 +775,6 @@ WriteProtected<byte>(0xDFF34C, 0xEB);
 
 Patch "Disable Super Sonic Floating Boost (Air Boost)" by "Skyth"
 WriteProtected<byte>(0xDFE04C, 0xEB);
+
+Patch "Disable Rail Boosters" by "Hyper"
+WriteProtected<byte>(0x166F238, 0x00);

--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -621,6 +621,7 @@ WriteProtected<uint>(0x10C65CB, 0x85);
 WriteProtected<uint>(0x10C65F5, 0x85);
 
 Patch "Disable Spin Jump Particles" by "Hyper"
+WriteProtected<byte>(0x15F99DC, 0x00);
 WriteProtected<byte>(0x15E902C, 0x00);
 
 Patch "Disable Light Dash Particles" by "Hyper"
@@ -751,6 +752,8 @@ WriteNop(0x11A9ECB, 2);
 Patch "Disable Boost Particles" by "Hyper"
 WriteProtected<byte>(0x15E9048, 0x00);
 WriteProtected<byte>(0x15E9060, 0x00);
+WriteProtected<byte>(0x15F99F8, 0x00);
+WriteProtected<byte>(0x15F9A10, 0x00);
 
 Patch "Disable Air Boost" by "Sajid"
 WriteProtected<byte>(0x00DFDFC4, 0xEB, 0x27)


### PR DESCRIPTION
Updated Disable Boost Particles and Disable Spin Jump Particles to work with Super Sonic.