### PR TITLE
Make more strings localisable and improve portuguese translations

### DIFF
--- a/HedgeModManager/Languages/en-AU.xaml
+++ b/HedgeModManager/Languages/en-AU.xaml
@@ -8,6 +8,7 @@
     <system:String x:Key="CommonUIOK"     >OK</system:String>
     <system:String x:Key="CommonUICancel" >Cancel</system:String>
     <system:String x:Key="CommonUIYes"    >Yes</system:String>
+    <system:String x:Key="CommonUIBlocked"    >Blocked</system:String>
     <system:String x:Key="CommonUINo"     >No</system:String>
     <system:String x:Key="CommonUIRetry"  >Retry</system:String>
     <system:String x:Key="CommonUIUpdate" >Update</system:String>
@@ -146,8 +147,12 @@
     <system:String x:Key="StatusUINoCodeUpdatesFound"     >No code updates found</system:String>
     
     <!-- Dialog UI Strings -->
+    <system:String xml:space="preserve" x:Key="DialogUINoModsFolder">Hedge Mod Manager did not detect any mods folder.&#x0a;Would you like create a mods folder?</system:String>
     <system:String xml:space="preserve" x:Key="DialogUIDeleteMod">Are you sure you want to delete "{0}"?&#x0a;This action cannot be undone!</system:String>
-    
+    <system:String xml:space="preserve" x:Key="DialogUIModNewest">{0} is already up to date.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModUpdate">A newer version of {0} available! ({1})</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate">Are you sure you want to cancel updating?&#x0a;This may corrupt {0}</system:String>
+
     <!-- Status UI Lang Stuff Strings -->
     <system:String x:Key="StatusUIUpdateCompletedSingular"      >completed</system:String>
     <system:String x:Key="StatusUIUpdateCompletedPlural"        >completed</system:String>
@@ -156,6 +161,11 @@
 
     <!-- Mod Config UI Strings -->
     <system:String x:Key="ModConfigUITitle">Configure {0}</system:String>
+
+    <!-- Mod Description UI Strings -->
+    <system:String x:Key="ModDescriptionUIAbout">About {0}</system:String>
+    <system:String x:Key="ModDescriptionUIMadeBy">Made by</system:String>
+    <system:String x:Key="ModDescriptionUIDate">on</system:String>
 
     <!-- Mod Downloader Strings -->
     <system:String x:Key="ModDownloaderFailed">Failed to Download Mod</system:String>

--- a/HedgeModManager/Languages/pt-BR.xaml
+++ b/HedgeModManager/Languages/pt-BR.xaml
@@ -9,6 +9,7 @@
     <system:String x:Key="CommonUICancel" >Cancelar</system:String>
     <system:String x:Key="CommonUIYes"    >Sim</system:String>
     <system:String x:Key="CommonUINo"     >Não</system:String>
+    <system:String x:Key="CommonUIBlocked"    >Bloqueado</system:String>
     <system:String x:Key="CommonUIRetry"  >Tentar Novamente</system:String>
     <system:String x:Key="CommonUIUpdate" >Atualizar</system:String>
     <system:String x:Key="CommonUIDelete" >Apagar</system:String>
@@ -67,9 +68,9 @@
     <system:String x:Key="SettingsUILabelMDir"      >Diretoria de Mods:</system:String>
     <!--   Hedge Mod Manager -->
     <system:String x:Key="SettingsUIHMMHeader"      >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"  >Verificar por atualizações do carregador de mods</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"  >Verificar por atualizações do carregador de códigos</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates">Verificar por atualizações de mods</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"  >Buscar atualizações do carregador de mods</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"  >Buscar atualizações do carregador de códigos</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates">Buscar atualizações de mods</system:String>
     <system:String x:Key="SettingsUIKeepHMMOpen"    >Manter o Hedge Mod Manager aberto após iniciar um jogo</system:String>
     <system:String x:Key="SettingsUIAboutHMM"       >Sobre o Hedge Mod Manager</system:String>
     <system:String x:Key="SettingsUILanguage"       >Idioma:</system:String>
@@ -81,7 +82,7 @@
     <system:String x:Key="MainUIInstallFormOptionArc">Instalar de um arquivo</system:String>
     <system:String x:Key="MainUIInstallFormOptionNew">Criar um (para desenvolvedores!)</system:String>
     <system:String x:Key="MainUIMissingLoaderHeader" >Carregador de Mods Não Instalado!</system:String>
-    <system:String xml:space="preserve" x:Key="MainUIMissingLoaderDesc"   >Para que {0} possa carregar mods, o carregador de mods precisa de estar instalado.&#x0a;Quer instalar agora?</system:String>
+    <system:String xml:space="preserve" x:Key="MainUIMissingLoaderDesc"   >Para que {0} possa carregar mods, o carregador de mods precisa de estar instalado.&#x0a;Quer instala-lo agora?</system:String>
     <system:String x:Key="MainUISelectModsDBTitle"   >Selecione de onde pretende carregar mods...</system:String>
     <system:String x:Key="MainUIRuntimeMissingTitle" >Runtime Em Falta Detetada!</system:String>
     <system:String x:Key="MainUIRuntimeMissingMsg" xml:space="preserve">{0} requer que {1} esteja instalado/a para que os mods funcionem corretamente. Quer que o HMM instale essa runtime?</system:String>
@@ -124,16 +125,16 @@
 
     <!-- Status UI Strings -->
     <system:String x:Key="StatusUILoadedMods"             >{0} mods carregados</system:String>
-    <system:String x:Key="StatusUICheckingModUpdates"     >Verificando por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUICheckingModUpdates"     >Buscando atualizações de {0}</system:String>
     <system:String x:Key="StatusUIFailedToUpdate"         >Falha ao atualizar {0}! {1}</system:String>
-    <system:String x:Key="StatusUIModUpdateCheckFinish"   >Verificação de atualizações de mods terminada: {0} {2}, {1} {3}.</system:String>
+    <system:String x:Key="StatusUIModUpdateCheckFinish"   >Busca de atualizações de mods terminada: {0} {2}, {1} {3}.</system:String>
     <system:String x:Key="StatusUIStartingGame"           >Iniciando {0}</system:String>
-    <system:String x:Key="StatusUICheckingForUpdates"     >Verificando por atualizações</system:String>
+    <system:String x:Key="StatusUICheckingForUpdates"     >Buscando atualizações</system:String>
     <system:String x:Key="StatusUINoUpdatesFound"         >Nenhuma atualização encontrada</system:String>
-    <system:String x:Key="StatusUIFailedToCheckUpdates"   >Falha ao verificar por atualizações</system:String>
-    <system:String x:Key="StatusUICheckingForLoaderUpdate">Verificando por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUIFailedToCheckUpdates"   >Falha ao buscar atualizações</system:String>
+    <system:String x:Key="StatusUICheckingForLoaderUpdate">Buscando atualizações de {0}</system:String>
     <system:String x:Key="StatusUILoaderUpToDate"         >{0} está atualizado</system:String>
-    <system:String x:Key="StatusUIFailedLoaderUpdateCheck">Falha ao verificar por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUIFailedLoaderUpdateCheck">Falha ao buscar atualizações de {0}</system:String>
     <system:String x:Key="StatusUIInstalledLoader"        >{0} instalado</system:String>
     <system:String x:Key="StatusUIDeletedMod"             >{0} apagado</system:String>
     <system:String x:Key="StatusUIModsDBSaved"            >Base de dados de mods guardada</system:String>
@@ -146,7 +147,11 @@
     <system:String x:Key="StatusUINoCodeUpdatesFound"     >Nenhuma atualização de códigos encontrada</system:String>
 
     <!-- Dialog UI Strings -->
+    <system:String xml:space="preserve" x:Key="DialogUINoModsFolder">O Hedge Mod Manager não detetou uma pasta para mods.&#x0a;Quer que esta seja criada?</system:String>
     <system:String xml:space="preserve" x:Key="DialogUIDeleteMod">Tem a certeza de que pretende apagar "{0}"?&#x0a;Esta ação não pode ser desfeita!</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModNewest">{0} já está atualizado.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModUpdate">Uma versão mais recente de {0} está disponível! ({1})</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate">Tem a certeza de que pretende cancelar a atualização?&#x0a;Esta ação pode corrumper {0}</system:String>
 
     <!-- Status UI Lang Stuff Strings -->
     <system:String x:Key="StatusUIUpdateCompletedSingular"      >concluída</system:String>
@@ -156,6 +161,11 @@
 
     <!-- Mod Config UI Strings -->
     <system:String x:Key="ModConfigUITitle">Configurar {0}</system:String>
+
+    <!-- Mod Description UI Strings -->
+    <system:String x:Key="ModDescriptionUIAbout">Acerca de {0}</system:String>
+    <system:String x:Key="ModDescriptionUIMadeBy">Feito por</system:String>
+    <system:String x:Key="ModDescriptionUIDate">a</system:String>
 
     <!-- Mod Downloader Strings -->
     <system:String x:Key="ModDownloaderFailed">Falha ao Baixar Mod</system:String>

--- a/HedgeModManager/Languages/pt-PT.xaml
+++ b/HedgeModManager/Languages/pt-PT.xaml
@@ -9,6 +9,7 @@
     <system:String x:Key="CommonUICancel" >Cancelar</system:String>
     <system:String x:Key="CommonUIYes"    >Sim</system:String>
     <system:String x:Key="CommonUINo"     >Não</system:String>
+    <system:String x:Key="CommonUIBlocked"    >Bloqueado</system:String>
     <system:String x:Key="CommonUIRetry"  >Tentar Novamente</system:String>
     <system:String x:Key="CommonUIUpdate" >Atualizar</system:String>
     <system:String x:Key="CommonUIDelete" >Apagar</system:String>
@@ -39,11 +40,11 @@
     <system:String x:Key="ModsUIModFavorite"    >Favorito</system:String>
     <system:String x:Key="ModsUIModConfigure"   >Configurar mod</system:String>
     <system:String x:Key="ModsUIModOpenFolder"  >Abrir pasta do conteúdo</system:String>
-    <system:String x:Key="ModsUIModCheckUpdates">Verificar por atualizações</system:String>
+    <system:String x:Key="ModsUIModCheckUpdates">Procurar atualizações</system:String>
     <system:String x:Key="ModsUIModEdit"        >Editar mod</system:String>
     <system:String x:Key="ModsUIModDelete"      >Remover mod</system:String>
     <system:String x:Key="ModsUIModDragDrop"    >Arrasta items para alterar a ordem de carregamento de mods.</system:String>
-    <system:String xml:space="preserve" x:Key="ModsUIInvalidIncludeDirs">O Hedge Mod Manager detetou que um ou mais mods têm diretorias inválidas.&#x0a;Queres que o Hedge Mod Manager tente corrigir isto?</system:String>
+    <system:String xml:space="preserve" x:Key="ModsUIInvalidIncludeDirs">O Hedge Mod Manager detetou que um ou mais mods têm diretorias inválidas.&#x0a;Queres que o Hedge Mod Manager tente corrigir este problema?</system:String>
 
     <!-- Codes UI Strings -->
     <system:String x:Key="CodesUIName"    >Nome</system:String>
@@ -67,22 +68,22 @@
     <system:String x:Key="SettingsUILabelMDir"      >Diretoria de Mods:</system:String>
     <!--   Hedge Mod Manager -->
     <system:String x:Key="SettingsUIHMMHeader"      >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"  >Verificar por atualizações do carregador de mods</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"  >Verificar por atualizações do carregador de códigos</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates">Verificar por atualizações de mods</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"  >Procurar atualizações do carregador de mods</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"  >Procurar atualizações do carregador de códigos</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates">Procurar atualizações de mods</system:String>
     <system:String x:Key="SettingsUIKeepHMMOpen"    >Manter o Hedge Mod Manager aberto após iniciar um jogo</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"       >Sobre o Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"       >Acerca do Hedge Mod Manager</system:String>
     <system:String x:Key="SettingsUILanguage"       >Idioma:</system:String>
     <system:String x:Key="SettingsUITheme"          >Tema:</system:String>
 
     <!-- MainWindow UI Strings -->
     <system:String x:Key="MainUIInstallFormHeader"   >Instalar um mod através de...</system:String>
-    <system:String x:Key="MainUIInstallFormOptionDir">Instalar de uma pasta</system:String>
-    <system:String x:Key="MainUIInstallFormOptionArc">Instalar de um arquivo</system:String>
+    <system:String x:Key="MainUIInstallFormOptionDir">Instalar a partir de uma pasta</system:String>
+    <system:String x:Key="MainUIInstallFormOptionArc">Instalar a partir de um arquivo</system:String>
     <system:String x:Key="MainUIInstallFormOptionNew">Criar um (para desenvolvedores!)</system:String>
     <system:String x:Key="MainUIMissingLoaderHeader" >Carregador de Mods Não Instalado!</system:String>
     <system:String xml:space="preserve" x:Key="MainUIMissingLoaderDesc"   >De maneira a que {0} possa carregar mods, o carregador de mods precisa de estar instalado.&#x0a;Queres instala-lo agora?</system:String>
-    <system:String x:Key="MainUISelectModsDBTitle"   >Seleciona de onde pretendes carregar mods...</system:String>
+    <system:String x:Key="MainUISelectModsDBTitle"   >Seleciona a pasta de onde pretendes carregar mods...</system:String>
     <system:String x:Key="MainUIRuntimeMissingTitle" >Runtime Em Falta Detetada!</system:String>
     <system:String x:Key="MainUIRuntimeMissingMsg" xml:space="preserve">{0} requer que {1} esteja instalado/a para que os mods funcionem corretamente. Queres que o HMM instale esta runtime?</system:String>
     <system:String x:Key="MainUISaveFileRedirectionDisabled" xml:space="preserve">Um ou mais mods ativados requerem o redirecionamento do ficheiro de gravação para funcionarem corretamente. Ativar esta funcionalidade?&#x0a;Clica "não" apenas se souberes o que estás a fazer.</system:String>
@@ -93,7 +94,7 @@
     <system:String x:Key="OptionsWindowUIError"      >Por favor seleciona uma opção!</system:String>
 
     <!-- AboutWindow UI Strings -->
-    <system:String x:Key="AboutWindowUITitle">Sobre o Hedge Mod Manager</system:String>
+    <system:String x:Key="AboutWindowUITitle">Acerda do Hedge Mod Manager</system:String>
     <system:String x:Key="AboutWindowUILine1">Um programa desenhado para facilitar o carregamento de mods para a Hedgehog Engine.</system:String>
     <system:String x:Key="AboutWindowUILine2">Requer uma cópia legal de um dos jogos suportados.</system:String>
     <system:String x:Key="AboutWindowUICredits">Créditos</system:String>
@@ -124,16 +125,16 @@
 
     <!-- Status UI Strings -->
     <system:String x:Key="StatusUILoadedMods"             >{0} mods carregados</system:String>
-    <system:String x:Key="StatusUICheckingModUpdates"     >A verificar por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUICheckingModUpdates"     >A procurar atualizações de {0}</system:String>
     <system:String x:Key="StatusUIFailedToUpdate"         >Falha ao atualizar {0}! {1}</system:String>
-    <system:String x:Key="StatusUIModUpdateCheckFinish"   >Verificação de atualizações de mods terminada: {0} {2}, {1} {3}.</system:String>
+    <system:String x:Key="StatusUIModUpdateCheckFinish"   >Procura de atualizações de mods terminada: {0} {2}, {1} {3}.</system:String>
     <system:String x:Key="StatusUIStartingGame"           >A iniciar {0}</system:String>
-    <system:String x:Key="StatusUICheckingForUpdates"     >A verificar por atualizações</system:String>
+    <system:String x:Key="StatusUICheckingForUpdates"     >A procurar atualizações</system:String>
     <system:String x:Key="StatusUINoUpdatesFound"         >Nenhuma atualização encontrada</system:String>
-    <system:String x:Key="StatusUIFailedToCheckUpdates"   >Falha ao verificar por atualizações</system:String>
-    <system:String x:Key="StatusUICheckingForLoaderUpdate">A verificar por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUIFailedToCheckUpdates"   >Falha ao procurar atualizações</system:String>
+    <system:String x:Key="StatusUICheckingForLoaderUpdate">A procurar por atualizações de {0}</system:String>
     <system:String x:Key="StatusUILoaderUpToDate"         >{0} está atualizado</system:String>
-    <system:String x:Key="StatusUIFailedLoaderUpdateCheck">Falha ao verificar por atualizações de {0}</system:String>
+    <system:String x:Key="StatusUIFailedLoaderUpdateCheck">Falha ao procurar atualizações de {0}</system:String>
     <system:String x:Key="StatusUIInstalledLoader"        >{0} instalado</system:String>
     <system:String x:Key="StatusUIDeletedMod"             >{0} apagado</system:String>
     <system:String x:Key="StatusUIModsDBSaved"            >Base de dados de mods guardada</system:String>
@@ -146,7 +147,11 @@
     <system:String x:Key="StatusUINoCodeUpdatesFound"     >Nenhuma atualização de códigos encontrada</system:String>
 
     <!-- Dialog UI Strings -->
+    <system:String xml:space="preserve" x:Key="DialogUINoModsFolder">O Hedge Mod Manager não detetou uma pasta para mods.&#x0a;Queres que esta seja criada?</system:String>
     <system:String xml:space="preserve" x:Key="DialogUIDeleteMod">Tens a certeza de que pretendes apagar "{0}"?&#x0a;Esta ação não pode ser desfeita!</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModNewest">{0} já está atualizado.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModUpdate">Uma versão mais recente de {0} está disponível! ({1})</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate">Tens a certeza de que pretendes cancelar a atualização?&#x0a;Esta ação pode corrumper {0}</system:String>
 
     <!-- Status UI Lang Stuff Strings -->
     <system:String x:Key="StatusUIUpdateCompletedSingular"      >concluída</system:String>
@@ -156,6 +161,11 @@
 
     <!-- Mod Config UI Strings -->
     <system:String x:Key="ModConfigUITitle">Configurar {0}</system:String>
+
+    <!-- Mod Description UI Strings -->
+    <system:String x:Key="ModDescriptionUIAbout">Acerca de {0}</system:String>
+    <system:String x:Key="ModDescriptionUIMadeBy">Feito por</system:String>
+    <system:String x:Key="ModDescriptionUIDate">a</system:String>
 
     <!-- Mod Downloader Strings -->
     <system:String x:Key="ModDownloaderFailed">Falha ao Transferir Mod</system:String>

--- a/HedgeModManager/Properties/Resources.Designer.cs
+++ b/HedgeModManager/Properties/Resources.Designer.cs
@@ -130,12 +130,7 @@ namespace HedgeModManager.Properties {
         ///}
         ///
         ///th, td {
-        ///    padding: 2px;
-        ///}
-        ///
-        ///th {
-        ///    text-align: left;
-        ///}.
+        ///    padding:  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string GBStyleSheet {
             get {
@@ -218,25 +213,6 @@ namespace HedgeModManager.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to cancel updating?
-        ///This may corrupt {0}.
-        /// </summary>
-        internal static string STR_CANCEL_WARNING {
-            get {
-                return ResourceManager.GetString("STR_CANCEL_WARNING", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is already up to date..
-        /// </summary>
-        internal static string STR_MOD_NEWEST {
-            get {
-                return ResourceManager.GetString("STR_MOD_NEWEST", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to HedgeModManager could not detect any supported games
         ///in the current directory!
         ///
@@ -245,25 +221,6 @@ namespace HedgeModManager.Properties {
         internal static string STR_MSG_NOGAME {
             get {
                 return ResourceManager.GetString("STR_MSG_NOGAME", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A newer version of {0} available! ({1}).
-        /// </summary>
-        internal static string STR_UI_MOD_UPDATE {
-            get {
-                return ResourceManager.GetString("STR_UI_MOD_UPDATE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hedge Mod Manager did not detect any mods folder.
-        ///Would you like create a mods folder?.
-        /// </summary>
-        internal static string STR_UI_NO_MODS {
-            get {
-                return ResourceManager.GetString("STR_UI_NO_MODS", resourceCulture);
             }
         }
         

--- a/HedgeModManager/Properties/Resources.resx
+++ b/HedgeModManager/Properties/Resources.resx
@@ -142,25 +142,11 @@
   <data name="MemoryService" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MemoryService.cs;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
-  <data name="STR_CANCEL_WARNING" xml:space="preserve">
-    <value>Are you sure you want to cancel updating?
-This may corrupt {0}</value>
-  </data>
-  <data name="STR_MOD_NEWEST" xml:space="preserve">
-    <value>{0} is already up to date.</value>
-  </data>
   <data name="STR_MSG_NOGAME" xml:space="preserve">
     <value>HedgeModManager could not detect any supported games
 in the current directory!
 
 Do you want run the HMM Auto Installer?</value>
-  </data>
-  <data name="STR_UI_MOD_UPDATE" xml:space="preserve">
-    <value>A newer version of {0} available! ({1})</value>
-  </data>
-  <data name="STR_UI_NO_MODS" xml:space="preserve">
-    <value>Hedge Mod Manager did not detect any mods folder.
-Would you like create a mods folder?</value>
   </data>
   <data name="URL_FML_CODES" xml:space="preserve">
     <value>https://raw.githubusercontent.com/thesupersonic16/HedgeModManager/rewrite/HedgeModManager/Resources/Codesv2/SonicForces.hmm</value>

--- a/HedgeModManager/UI/AboutModWindow.xaml
+++ b/HedgeModManager/UI/AboutModWindow.xaml
@@ -17,17 +17,17 @@
             HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <TextBlock x:Name="TitleLbl" Text="Title" FontSize="26" Width="Auto"/>
             <TextBlock FontSize="14" Width="Auto" Visibility="{Binding AuthorURL, Converter={StaticResource EmptyStringToVisibilityConverter}}">
-                <Run Text="Made by"/>
+                <Run Text="{StaticResource ModDescriptionUIMadeBy}"/>
                 <Hyperlink NavigateUri="{Binding AuthorURL}" Click="Hyperlink_OnClick">
                     <Run Text="{Binding Author}" Foreground="{DynamicResource HMM.Window.HeaderAccentBrush}"/>
                 </Hyperlink>
-                <Run Text="on"/>
+                <Run Text="{StaticResource ModDescriptionUIDate}"/>
                 <Run Text="{Binding Date}"/>
             </TextBlock>
             <TextBlock FontSize="14" Width="Auto" Visibility="{Binding AuthorURL, Converter={StaticResource InverseEmptyStringToVisibilityConverter}}">
-                <Run Text="Made by"/>
+                <Run Text="{StaticResource ModDescriptionUIMadeBy}"/>
                 <Run Text="{Binding Author}"/>
-                <Run Text="on"/>
+                <Run Text="{StaticResource ModDescriptionUIDate}"/>
                 <Run Text="{Binding Date}"/>
             </TextBlock>
         </StackPanel>

--- a/HedgeModManager/UI/AboutModWindow.xaml.cs
+++ b/HedgeModManager/UI/AboutModWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace HedgeModManager
         {
             DataContext = mod;
             InitializeComponent();
-            Title = $"About {mod.Title}";
+            Title = string.Format(Lang.Localise("ModDescriptionUIAbout"), mod.Title);
             TitleLbl.Text = $"{mod.Title}";
             if (!string.IsNullOrEmpty(mod.Version))
             {

--- a/HedgeModManager/UI/Converters.cs
+++ b/HedgeModManager/UI/Converters.cs
@@ -16,9 +16,9 @@ namespace HedgeModManager
         {
             var server = (string)value;
             if (string.IsNullOrEmpty(server))
-                return "No";
+                return Lang.Localise("CommonUINo");
 
-            return HedgeApp.NetworkConfiguration.IsServerBlocked(server) ? "Blocked" : "Yes";
+            return HedgeApp.NetworkConfiguration.IsServerBlocked(server) ? Lang.Localise("CommonUIBlocked") : Lang.Localise("CommonUIYes");
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -104,7 +104,7 @@ namespace HedgeModManager
             if (!Directory.Exists(HedgeApp.ModsDbPath))
             {
                 Application.Current?.MainWindow?.Hide();
-                var box = new HedgeMessageBox("No Mods Found", Properties.Resources.STR_UI_NO_MODS);
+                var box = new HedgeMessageBox("No Mods Found", Localise("DialogUINoModsFolder"));
 
                 box.AddButton("Yes", () =>
                 {
@@ -322,14 +322,14 @@ namespace HedgeModManager
                     {
                         if (showUpdatedDialog)
                         {
-                            var box = new HedgeMessageBox(string.Empty, string.Format(HMMResources.STR_MOD_NEWEST, mod.Title));
+                            var box = new HedgeMessageBox(string.Empty, string.Format(Localise("DialogUIModNewest"), mod.Title));
                             box.AddButton(Localise("CommonUIOK"), () => box.Close());
                             box.ShowDialog();
                         }
                         return;
                     }
 
-                    var dialog = new HedgeMessageBox(string.Format(HMMResources.STR_UI_MOD_UPDATE, mod.Title, update.VersionString)
+                    var dialog = new HedgeMessageBox(string.Format(Localise("DialogUIModUpdate"), mod.Title, update.VersionString)
                         , update.ChangeLog, type: InputType.MarkDown);
 
                     dialog.AddButton(Localise("CommonUIUpdate"), () =>

--- a/HedgeModManager/UI/ModUpdateWindow.xaml.cs
+++ b/HedgeModManager/UI/ModUpdateWindow.xaml.cs
@@ -143,7 +143,7 @@ namespace HedgeModManager.UI
             }
 
             e.Cancel = true;
-            WarningDialog = new HedgeMessageBox("Hedge Mod Manager", string.Format(HMMResources.STR_CANCEL_WARNING, UpdateInfo.Mod.Title));
+            WarningDialog = new HedgeMessageBox("Hedge Mod Manager", string.Format(Lang.Localise("DialogUIModCancelUpdate"), UpdateInfo.Mod.Title));
 
             WarningDialog.AddButton("Yes", () =>
             {


### PR DESCRIPTION
This PR enables the localisation of some strings by moving them out of Resources.resx and placing them in the XAML language files. It also improves the portuguese translations by translating those strings and tweaking some other ones.