### PR TITLE
Improved TabControl styling

### DIFF
--- a/HedgeModManager/HedgeApp.xaml
+++ b/HedgeModManager/HedgeApp.xaml
@@ -314,7 +314,9 @@
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
                                 <TabPanel IsItemsHost="True"/>
-                                <Border BorderThickness="0,2,0,0" BorderBrush="{DynamicResource HMM.Window.AccentBrush2}" Grid.Row="1">
+                                <Border BorderThickness="0,2,0,0" 
+                                        BorderBrush="{DynamicResource HMM.Window.AccentBrush2}" 
+                                        Grid.Row="1">
                                     <Grid Margin="0,5,0,0">
                                         <ContentPresenter x:Name="PART_Presenter" ContentSource="SelectedContent" HorizontalAlignment="Stretch"/>
                                         <Rectangle x:Name="PART_TempArea"/>
@@ -394,7 +396,8 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TabItem}">
                             <Border BorderBrush="Transparent" Width="{TemplateBinding Width}" 
-                                    Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                    Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"
+                                    CornerRadius="4,4,0,0">
                                 <TextBlock Text="{TemplateBinding Header}" Foreground="{TemplateBinding Foreground}" VerticalAlignment="Center"/>
                             </Border>
                             <ControlTemplate.Triggers>

--- a/HedgeModManager/HedgeApp.xaml
+++ b/HedgeModManager/HedgeApp.xaml
@@ -397,7 +397,7 @@
                         <ControlTemplate TargetType="{x:Type TabItem}">
                             <Border BorderBrush="Transparent" Width="{TemplateBinding Width}" 
                                     Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"
-                                    CornerRadius="4,4,0,0">
+                                    CornerRadius="2,2,0,0">
                                 <TextBlock Text="{TemplateBinding Header}" Foreground="{TemplateBinding Foreground}" VerticalAlignment="Center"/>
                             </Border>
                             <ControlTemplate.Triggers>

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -469,7 +469,7 @@ namespace HedgeModManager
         public static void FindMissingLanguageEntries(string culture)
         {
             var entry = GetClosestCulture(culture);
-            var baseDict = new ResourceDictionary {Source = new Uri("Languages/en-AU.xaml", UriKind.Relative)};
+            var baseDict = new ResourceDictionary { Source = new Uri("Languages/en-AU.xaml", UriKind.Relative) };
             var builder = new StringBuilder();
             builder.AppendLine();
 
@@ -682,7 +682,7 @@ namespace HedgeModManager
             }
             catch (Exception e)
             {
-                CreateOKMessageBox("Hedge Mod Manager", 
+                CreateOKMessageBox("Hedge Mod Manager",
                     installed ? Lang.Localise("MainUIMLUninstallFail") : Lang.Localise("MainUIMLInstallFail")).ShowDialog();
                 return false;
             }
@@ -959,38 +959,43 @@ namespace HedgeModManager
 
         private void TabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (e.RemovedItems.Count < 1 || !(e.RemovedItems[0] is FrameworkElement))
+            if (e.RemovedItems.Count < 1 || e.AddedItems.Count < 1 || !(e.RemovedItems[0] is FrameworkElement))
                 return;
-
-
 
             var oldControl = (FrameworkElement)((TabItem)e.RemovedItems[0]).Content;
             var control = (TabControl)sender;
-            var left = control.Items.IndexOf(e.RemovedItems[0]) < control.Items.IndexOf(e.AddedItems[0]);
+
+            var isLeft = control.Items.IndexOf(e.RemovedItems[0]) < control.Items.IndexOf(e.AddedItems[0]);
 
             var tempArea = (System.Windows.Shapes.Shape)control.Template.FindName("PART_TempArea", (FrameworkElement)sender);
             var presenter = (ContentPresenter)control.Template.FindName("PART_Presenter", (FrameworkElement)sender);
+
+            //control.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            //control.Arrange(new Rect(control.DesiredSize));
+
             var target = new RenderTargetBitmap((int)control.ActualWidth, (int)control.ActualHeight, 96, 96, PixelFormats.Pbgra32);
             target.Render(oldControl);
             tempArea.HorizontalAlignment = HorizontalAlignment.Stretch;
+            tempArea.VerticalAlignment = VerticalAlignment.Stretch;
             tempArea.Fill = new ImageBrush(target);
+            tempArea.Width = target.Width;
+            tempArea.Height = target.Height;
             tempArea.RenderTransform = new TranslateTransform();
             presenter.RenderTransform = new TranslateTransform();
 
-            presenter.RenderTransform.BeginAnimation(TranslateTransform.XProperty, left ? CreateAnimation(control.ActualWidth, 0) : CreateAnimation(-control.ActualWidth, 0));
-            tempArea.RenderTransform.BeginAnimation(TranslateTransform.XProperty, left ?
+            presenter.RenderTransform.BeginAnimation(TranslateTransform.XProperty, isLeft ? CreateAnimation(control.ActualWidth, 0) : CreateAnimation(-control.ActualWidth, 0));
+            tempArea.RenderTransform.BeginAnimation(TranslateTransform.XProperty, isLeft ?
                 CreateAnimation(0, -control.ActualWidth, (x, y) => { tempArea.HorizontalAlignment = HorizontalAlignment.Left; }) :
                 CreateAnimation(0, control.ActualWidth, (x, y) => { tempArea.HorizontalAlignment = HorizontalAlignment.Left; })
                 );
 
-            tempArea.Fill.BeginAnimation(Brush.OpacityProperty, CreateAnimation(1, 0));
+            tempArea.BeginAnimation(UIElement.OpacityProperty, CreateAnimation(1, 0));
 
 
-            AnimationTimeline CreateAnimation(double from, double to,
-                          EventHandler whenDone = null)
+            AnimationTimeline CreateAnimation(double from, double to, EventHandler whenDone = null)
             {
                 var ease = new ExponentialEase { Exponent = 7, EasingMode = EasingMode.EaseOut };
-                var duration = new Duration(TimeSpan.FromSeconds(0.4));
+                var duration = new Duration(TimeSpan.FromSeconds(1.0 / 3.0));
                 var anim = new DoubleAnimation(from, to, duration) { EasingFunction = ease };
                 if (whenDone != null)
                     anim.Completed += whenDone;

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -966,15 +966,12 @@ namespace HedgeModManager
             var control = (TabControl)sender;
 
             var isLeft = control.Items.IndexOf(e.RemovedItems[0]) < control.Items.IndexOf(e.AddedItems[0]);
-
             var tempArea = (System.Windows.Shapes.Shape)control.Template.FindName("PART_TempArea", (FrameworkElement)sender);
             var presenter = (ContentPresenter)control.Template.FindName("PART_Presenter", (FrameworkElement)sender);
-
-            //control.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-            //control.Arrange(new Rect(control.DesiredSize));
-
             var target = new RenderTargetBitmap((int)control.ActualWidth, (int)control.ActualHeight, 96, 96, PixelFormats.Pbgra32);
+
             target.Render(oldControl);
+
             tempArea.HorizontalAlignment = HorizontalAlignment.Stretch;
             tempArea.VerticalAlignment = VerticalAlignment.Stretch;
             tempArea.Fill = new ImageBrush(target);


### PR DESCRIPTION
Some small tweaks to the style of `TabControl` to make it feel a little more modern and less... goofy.

- Changes the direction of the tab animation depending on if the tab is to the left or right of the currently selected one
- Fixes a bug where the temporary old tab image would be scaled incorrectly
- Adds a 2px corner radius to the top of tabs to better match the rest of the app
- Slightly reduces the animation duration


<video controls src="https://user-images.githubusercontent.com/11337731/131421994-c40c53de-37c4-476e-9490-767e0a9d52a3.mp4"></video>

