### PR TITLE
[Sonic Generations] Disable Fast Music

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -849,3 +849,6 @@ WriteProtected<byte>(0x11C965F, 0x72)
 WriteProtected<byte>(0x11C966B, 0x72)
 WriteProtected<byte>(0x11C96CB, 0x72)
 WriteProtected<byte>(0x11C96DB, 0x72)
+
+Patch "Disable Fast Music" by "Hyper"
+WriteNop(0xE2E30F, 2);


### PR DESCRIPTION
Disables the music that plays when running at high speed in Green Hill and Sky Sanctuary - the boost tracks for both stages use the fast track, so those are left unaffected. For complete lack of fast music, use Disable Boost Audio Filter.

Alternatively, a sound mod could be created to make new boost versions of the default track, but I'm no good with sound design, so I'll leave that to someone more experienced. :P