### PR TITLE
[Sonic Generations] Disable Dropped Rings

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -872,3 +872,6 @@ Patch "Always Use Fast Music" by "Hyper"
 WriteProtected<byte>(0xE2E30F, 0xEB);
 WriteNop(0xE2E3A2, 2);
 WriteProtected<byte>(0xE2E3AC, 0xEB, 0x0E);
+
+Patch "Disable Dropped Rings" by "Hyper"
+WriteProtected<byte>(0x1055002, 0xE9, 0xBD, 0x03, 0x00, 0x00);


### PR DESCRIPTION
Disables the bouncy rings that you drop after taking damage like Unleashed.