### PR TITLE
Improved Settings tab layout and minor UI fixes

### DIFF
--- a/HedgeModManager/HedgeApp.xaml
+++ b/HedgeModManager/HedgeApp.xaml
@@ -300,12 +300,13 @@
             <Style TargetType="{x:Type TextBox}">
                 <Setter Property="Foreground" Value="{DynamicResource HMM.Window.ForegroundBrush}"/>
                 <Setter Property="Background" Value="{DynamicResource HMM.Window.BackgroundBrush1}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource HMM.Window.BorderBrush}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TextBox}">
                             <Border Background="{TemplateBinding Background}"
                                     x:Name="Bd"
-                                    BorderBrush="{DynamicResource HMM.Window.BorderBrush}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     CornerRadius="3">
                                 <ScrollViewer x:Name="PART_ContentHost"/>

--- a/HedgeModManager/HedgeApp.xaml
+++ b/HedgeModManager/HedgeApp.xaml
@@ -300,14 +300,35 @@
             <Style TargetType="{x:Type TextBox}">
                 <Setter Property="Foreground" Value="{DynamicResource HMM.Window.ForegroundBrush}"/>
                 <Setter Property="Background" Value="{DynamicResource HMM.Window.BackgroundBrush1}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource HMM.Window.BorderBrush}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type TextBox}">
+                            <Border Background="{TemplateBinding Background}"
+                                    x:Name="Bd"
+                                    BorderBrush="{DynamicResource HMM.Window.BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="3">
+                                <ScrollViewer x:Name="PART_ContentHost"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Background" Value="{DynamicResource HMM.Menu.DisabledColor}" TargetName="Bd"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource HMM.Menu.DisabledTextColor}"/>
+                                </Trigger>
+                                <Trigger Property="Width" Value="Auto">
+                                    <Setter Property="MinWidth" Value="100"/>
+                                </Trigger>
+                                <Trigger Property="Height" Value="Auto">
+                                    <Setter Property="MinHeight" Value="20"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
 
-            <Style TargetType="{x:Type pt:TextBoxEx}">
-                <Setter Property="Foreground" Value="{DynamicResource HMM.Window.ForegroundBrush}"/>
-                <Setter Property="Background" Value="{DynamicResource HMM.Window.BackgroundBrush1}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource HMM.Window.BorderBrush}" />
-            </Style>
+            <!-- PropertyTools TextBox style -->
+            <Style TargetType="{x:Type pt:TextBoxEx}" BasedOn="{StaticResource {x:Type TextBox}}"/>
 
             <!-- Tabs -->
             <Style TargetType="{x:Type TabControl}">
@@ -1170,7 +1191,7 @@
             <Style TargetType="{x:Type ComboBox}">
                 <Setter Property="Background" Value="{DynamicResource HMM.Button.BackgroundBrush}"/>
                 <Setter Property="Foreground" Value="{DynamicResource HMM.Button.ForegroundBrush}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource  HMM.Window.BorderBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource HMM.Window.BorderBrush}"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ComboBox}">

--- a/HedgeModManager/Languages/ru-RU.xaml
+++ b/HedgeModManager/Languages/ru-RU.xaml
@@ -72,7 +72,7 @@
     <system:String x:Key="SettingsUICheckCLUpdate"  >Проверять коды на наличие обновлений</system:String>
     <system:String x:Key="SettingsUICheckModUpdates">Проверять моды на наличие обновлений</system:String>
     <system:String x:Key="SettingsUIKeepHMMOpen"    >Оставить Hedge Mod Manager открытым после запуска игры</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"       >О программе Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUIAboutHMM" xml:space="preserve">О программе&#x0a;Hedge Mod Manager</system:String>
     <system:String x:Key="SettingsUILanguage"       >Язык:</system:String>
     <system:String x:Key="SettingsUITheme"          >Тема:</system:String>
 

--- a/HedgeModManager/Languages/ru-RU.xaml
+++ b/HedgeModManager/Languages/ru-RU.xaml
@@ -72,7 +72,7 @@
     <system:String x:Key="SettingsUICheckCLUpdate"  >Проверять коды на наличие обновлений</system:String>
     <system:String x:Key="SettingsUICheckModUpdates">Проверять моды на наличие обновлений</system:String>
     <system:String x:Key="SettingsUIKeepHMMOpen"    >Оставить Hedge Mod Manager открытым после запуска игры</system:String>
-    <system:String x:Key="SettingsUIAboutHMM" xml:space="preserve">О программе&#x0a;Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"       >О программе Hedge Mod Manager</system:String>
     <system:String x:Key="SettingsUILanguage"       >Язык:</system:String>
     <system:String x:Key="SettingsUITheme"          >Тема:</system:String>
 

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="Hedge Mod Manager (7.0)" Unloaded="MainWindow_OnUnloaded"
         Loaded="Window_Loaded" PreviewKeyDown="Window_PreviewKeyDown"
-        MinHeight="620" MinWidth="560" Height="620" Width="560" WindowStartupLocation="CenterScreen" Style="{StaticResource HedgeWindow}">
+        MinHeight="640" MinWidth="580" Height="640" Width="580" WindowStartupLocation="CenterScreen" Style="{StaticResource HedgeWindow}">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <local:BoolToYesNoConverter x:Key="BoolToYesNoConverter"/>

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -202,7 +202,7 @@
                     <TabItem x:Name="SettingsTab" Header="{DynamicResource MainUISettings}" Margin="2,0,-2,0">
                         <Grid Margin="10,5,10,5">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="220"/>
+                                <RowDefinition Height="228"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             
@@ -212,34 +212,34 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="114"/>
                                             <ColumnDefinition/>
-                                            <ColumnDefinition Width="24"/>
+                                            <ColumnDefinition Width="27"/>
                                         </Grid.ColumnDefinitions>
 
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="30"/>
+                                            <RowDefinition Height="32"/>
                                             <RowDefinition/>
                                         </Grid.RowDefinitions>
 
-                                        <Label   Content="{DynamicResource SettingsUILabelMDir}" Margin="1,-2,0,0"/>
-                                        <TextBox Text="{Binding ModsDB.RootDirectory}"           Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" IsReadOnly="True" Height="21"/>
-                                        <Button  Content="..."                                   Grid.Column="2" VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                        <Label   Content="{DynamicResource SettingsUILabelMDir}" Margin="1,0,0,0"/>
+                                        <TextBox Text="{Binding ModsDB.RootDirectory}"           Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" IsReadOnly="True" Height="27"/>
+                                        <Button  Content="..."                                   Grid.Column="2" VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="27" HorizontalAlignment="Right" Width="27"/>
 
-                                        <Label    Content="{DynamicResource SettingsUILabelProfile}" Grid.Row="1" Margin="1,-2,0,0"/>
-                                        <ComboBox x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="21" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Stretch"/>
-                                        <Button   Content="⚙" Grid.Column="2" VerticalAlignment="Top" Click="UI_ManageProfile_Click" Grid.Row="1" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                        <Label    Content="{DynamicResource SettingsUILabelProfile}" Grid.Row="1" Margin="1,0,0,0"/>
+                                        <ComboBox x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="27" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Stretch"/>
+                                        <Button   Content="⚙" Grid.Column="2" VerticalAlignment="Top" Click="UI_ManageProfile_Click" Grid.Row="1" Height="27" HorizontalAlignment="Right" Width="27"/>
                                     </Grid>
 
-                                    <StackPanel Margin="10,72,0,0">
+                                    <StackPanel Margin="10,80,0,0">
                                         <CheckBox Content="{DynamicResource SettingsUIEnableML}"          IsChecked="{Binding CPKREDIR.Enabled}"                       Margin="0,0,0,5"/>
                                         <CheckBox Content="{DynamicResource SettingsUIEnableDebug}"       IsChecked="{Binding CPKREDIR.EnableDebugConsole}"            Margin="0,0,0,5"/>
                                         <CheckBox Content="{DynamicResource SettingsUIEnableSRedir}"      IsChecked="{Binding CPKREDIR.EnableFallbackSaveRedirection}" Margin="0,0,0,5"/>
                                         <!--<CheckBox Content="{DynamicResource SettingsUILoadTopBottom}" IsChecked="{Binding ModsDB.ReverseLoadOrder}"                Visibility="{Binding HiddenMode, Converter={StaticResource BoolToVisibilityConverter}}"/>-->
                                     </StackPanel>
 
-                                    <StackPanel Margin="0,72,10,0" HorizontalAlignment="Right">
-                                        <Button x:Name="Button_OpenMods"    Content="{DynamicResource SettingsUIOpenMods}"        Click="UI_OpenMods_Click"    Margin="0,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200"/>
-                                        <Button                             Content="{DynamicResource SettingsUIOpenGameDir}"     Click="UI_OpenGameDir_Click" Margin="0,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200"/>
-                                        <Button x:Name="Button_OtherLoader" Content="{DynamicResource SettingsUIUninstallLoader}" Click="UI_OtherLoader_Click" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200" IsEnabled="False"/>
+                                    <StackPanel Margin="0,80,10,0" HorizontalAlignment="Right" Width="200">
+                                        <Button x:Name="Button_OpenMods"    Content="{DynamicResource SettingsUIOpenMods}"        Click="UI_OpenMods_Click"    Margin="0,0,0,5" HorizontalAlignment="Stretch" Height="27"/>
+                                        <Button                             Content="{DynamicResource SettingsUIOpenGameDir}"     Click="UI_OpenGameDir_Click" Margin="0,0,0,5" HorizontalAlignment="Stretch" Height="27"/>
+                                        <Button x:Name="Button_OtherLoader" Content="{DynamicResource SettingsUIUninstallLoader}" Click="UI_OtherLoader_Click"                  HorizontalAlignment="Stretch" Height="27" IsEnabled="False"/>
                                     </StackPanel>
                                 </Grid>
                             </GroupBox>
@@ -256,10 +256,10 @@
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition/>
-                                            <ColumnDefinition Width="200"/>
+                                            <ColumnDefinition Width="220"/>
                                         </Grid.ColumnDefinitions>
 
-                                        <Grid Margin="6,0,5,10" VerticalAlignment="Bottom">
+                                        <Grid Margin="6,0,0,10" VerticalAlignment="Bottom">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="32"/>
                                                 <RowDefinition Height="32"/>
@@ -281,7 +281,7 @@
                                             <ComboBox x:Name="ComboBox_Themes"    ItemsSource="{Binding InstalledThemes, Source={x:Static Application.Current}}"   SelectedItem="{Binding CurrentTheme, Source={x:Static Application.Current}}"   Grid.Row="2" Grid.Column="1" VerticalAlignment="Bottom" Height="27" SelectionChanged="ComboBox_Themes_Changed"    Loaded="ComboBox_Themes_Loaded"/>
                                         </Grid>
 
-                                        <StackPanel Grid.Column="1" Margin="0,0,10,10" VerticalAlignment="Bottom">
+                                        <StackPanel Grid.Column="1" Margin="0,0,0,10" VerticalAlignment="Bottom" Width="200">
                                             <Button Content="{DynamicResource SettingsUICheckHMMUpdate}" Height="43" Margin="0,0,0,5" Click="UI_CheckUpdates"/>
                                             <Button Content="{DynamicResource SettingsUIAboutHMM}"       Height="43" Click="UI_About_Click"/>
                                         </StackPanel>

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -208,30 +208,26 @@
                             
                             <GroupBox Header="{DynamicResource SettingsUIGMLHeader}" Margin="0,0,0,10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                 <Grid>
-                                    <StackPanel Margin="5,10,10,0">
-                                        <Grid Margin="0,0,0,5">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="114"/>
-                                                <ColumnDefinition/>
-                                                <ColumnDefinition Width="24"/>
-                                            </Grid.ColumnDefinitions>
+                                    <Grid Margin="5,10,10,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="114"/>
+                                            <ColumnDefinition/>
+                                            <ColumnDefinition Width="24"/>
+                                        </Grid.ColumnDefinitions>
 
-                                            <Label   Content="{DynamicResource SettingsUILabelMDir}" Margin="1,-2,0,0"/>
-                                            <TextBox Text="{Binding ModsDB.RootDirectory}"           Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" IsReadOnly="True" Height="21"/>
-                                            <Button  Content="..."                                   Grid.Column="2" VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
-                                        </Grid>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="114"/>
-                                                <ColumnDefinition/>
-                                                <ColumnDefinition Width="24"/>
-                                            </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="30"/>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
 
-                                            <Label    Content="{DynamicResource SettingsUILabelProfile}" Margin="1,-2,0,0"/>
-                                            <ComboBox x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="21" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Stretch"/>
-                                            <Button   Content="⚙" Grid.Column="2" VerticalAlignment="Top" Click="UI_ManageProfile_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
-                                        </Grid>
-                                    </StackPanel>
+                                        <Label   Content="{DynamicResource SettingsUILabelMDir}" Margin="1,-2,0,0"/>
+                                        <TextBox Text="{Binding ModsDB.RootDirectory}"           Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" IsReadOnly="True" Height="21"/>
+                                        <Button  Content="..."                                   Grid.Column="2" VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
+
+                                        <Label    Content="{DynamicResource SettingsUILabelProfile}" Grid.Row="1" Margin="1,-2,0,0"/>
+                                        <ComboBox x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="21" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Stretch"/>
+                                        <Button   Content="⚙" Grid.Column="2" VerticalAlignment="Top" Click="UI_ManageProfile_Click" Grid.Row="1" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                    </Grid>
 
                                     <StackPanel Margin="10,72,0,0">
                                         <CheckBox Content="{DynamicResource SettingsUIEnableML}"          IsChecked="{Binding CPKREDIR.Enabled}"                       Margin="0,0,0,5"/>

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -174,7 +174,7 @@
                                                         <DataTemplate>
                                                             <StackPanel Orientation="Horizontal">
                                                                 <CheckBox IsChecked="{Binding Enabled}" Margin="0,2,4,2"/>
-                                                                <TextBlock Text="{Binding Name}"/>
+                                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
                                                             </StackPanel>
                                                         </DataTemplate>
                                                     </GridViewColumn.CellTemplate>

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -200,47 +200,96 @@
                     </TabItem>
 
                     <TabItem x:Name="SettingsTab" Header="{DynamicResource MainUISettings}" Margin="2,0,-2,0">
-                        <Grid Margin="10,5,10,0">
+                        <Grid Margin="10,5,10,5">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="230"/>
+                                <RowDefinition Height="220"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <GroupBox Header="{DynamicResource SettingsUIGMLHeader}" HorizontalAlignment="Stretch" Margin="0,0,0.333,30" VerticalAlignment="Stretch">
+                            
+                            <GroupBox Header="{DynamicResource SettingsUIGMLHeader}" Margin="0,0,0,10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                 <Grid>
-                                    <Button   x:Name="Button_OtherLoader"   Content="Uninstall Mod Loader"                    Click="UI_OtherLoader_Click" Margin="10,7,0,0"    HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="193" IsEnabled="False"/>
-                                    <Button   x:Name="Button_OpenMods"      Content="{DynamicResource SettingsUIOpenMods}"    Click="UI_OpenMods_Click"    Margin="10,38,0,0"   HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="193"/>
+                                    <StackPanel Margin="5,10,10,0">
+                                        <Grid Margin="0,0,0,5">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="114"/>
+                                                <ColumnDefinition/>
+                                                <ColumnDefinition Width="24"/>
+                                            </Grid.ColumnDefinitions>
 
-                                    <StackPanel Margin="10,96,0,8">
-                                        <CheckBox Content="{DynamicResource SettingsUIEnableML}"      IsChecked="{Binding CPKREDIR.Enabled}"                    Margin="-1,5,0,0"   HorizontalAlignment="Left" VerticalAlignment="Top" />
-                                        <CheckBox Content="{DynamicResource SettingsUIEnableDebug}"   IsChecked="{Binding CPKREDIR.EnableDebugConsole}"         Margin="-1,5,0,0"   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                        <CheckBox Content="{DynamicResource SettingsUIEnableSRedir}"  IsChecked="{Binding CPKREDIR.EnableFallbackSaveRedirection}"  Margin="-1,5,0,0"   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                        <!--<CheckBox Content="{DynamicResource SettingsUILoadTopBottom}" IsChecked="{Binding ModsDB.ReverseLoadOrder}"             Margin="-1,5,0,0"   HorizontalAlignment="Left" VerticalAlignment="Top" Visibility="{Binding HiddenMode, Converter={StaticResource BoolToVisibilityConverter}}"/>-->
+                                            <Label   Content="{DynamicResource SettingsUILabelMDir}" Margin="1,-2,0,0"/>
+                                            <TextBox Text="{Binding ModsDB.RootDirectory}"           Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" IsReadOnly="True" Height="21"/>
+                                            <Button  Content="..."                                   Grid.Column="2" VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                        </Grid>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="114"/>
+                                                <ColumnDefinition/>
+                                                <ColumnDefinition Width="24"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <Label    Content="{DynamicResource SettingsUILabelProfile}" Margin="1,-2,0,0"/>
+                                            <ComboBox x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Grid.Column="1" Margin="0,0,5,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="21" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Stretch"/>
+                                            <Button   Content="⚙" Grid.Column="2" VerticalAlignment="Top" Click="UI_ManageProfile_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                        </Grid>
                                     </StackPanel>
 
-                                    <Label                                   Content="{DynamicResource SettingsUILabelProfile}" VerticalAlignment="Top" Margin="0,7,253,0" VerticalContentAlignment="Center" Height="27" HorizontalAlignment="Right" Width="62" />
-                                    <ComboBox   x:Name="ComboBox_ModProfile" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedModProfile}" DisplayMemberPath="Name" Margin="0,7,39,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Height="27" SelectionChanged="ComboBox_ModProfile_SelectionChanged" HorizontalAlignment="Right" Width="208" />
-                                    <Label                                   Content="{DynamicResource SettingsUILabelMDir}"   Margin="4,70,0,0"    HorizontalAlignment="Left" VerticalAlignment="Top" VerticalContentAlignment="Center"  />
-                                    <Button                                  Content="⚙"                                      Margin="0,8,10,0"   VerticalAlignment="Top" Click="UI_ManageProfile_Click" Height="24" HorizontalAlignment="Right" Width="24"/>
-                                    <Button                                  Content="{DynamicResource SettingsUIOpenGameDir}" Margin="0,38,10,0"   VerticalAlignment="Top" HorizontalAlignment="Right" Height="27" Width="237" Click="UI_OpenGameDir_Click"/>
-                                    <TextBox                                 Text="{Binding ModsDB.RootDirectory}"             Margin="113,73,39,0" VerticalAlignment="Top" IsReadOnly="True" Height="21"/>
-                                    <Button                                  Content="..."                                     Margin="0,73,10,0"   VerticalAlignment="Top" Click="UI_ChangeDatabasePath_Click" Height="21" HorizontalAlignment="Right" Width="24"/>
+                                    <StackPanel Margin="10,72,0,0">
+                                        <CheckBox Content="{DynamicResource SettingsUIEnableML}"          IsChecked="{Binding CPKREDIR.Enabled}"                       Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIEnableDebug}"       IsChecked="{Binding CPKREDIR.EnableDebugConsole}"            Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIEnableSRedir}"      IsChecked="{Binding CPKREDIR.EnableFallbackSaveRedirection}" Margin="0,0,0,5"/>
+                                        <!--<CheckBox Content="{DynamicResource SettingsUILoadTopBottom}" IsChecked="{Binding ModsDB.ReverseLoadOrder}"                Visibility="{Binding HiddenMode, Converter={StaticResource BoolToVisibilityConverter}}"/>-->
+                                    </StackPanel>
+
+                                    <StackPanel Margin="0,72,10,0" HorizontalAlignment="Right">
+                                        <Button x:Name="Button_OpenMods"    Content="{DynamicResource SettingsUIOpenMods}"        Click="UI_OpenMods_Click"    Margin="0,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200"/>
+                                        <Button                             Content="{DynamicResource SettingsUIOpenGameDir}"     Click="UI_OpenGameDir_Click" Margin="0,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200"/>
+                                        <Button x:Name="Button_OtherLoader" Content="{DynamicResource SettingsUIUninstallLoader}" Click="UI_OtherLoader_Click" HorizontalAlignment="Left" VerticalAlignment="Top" Height="27" Width="200" IsEnabled="False"/>
+                                    </StackPanel>
                                 </Grid>
                             </GroupBox>
 
-                            <GroupBox Header="{DynamicResource SettingsUIHMMHeader}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,209,0.333,5" Grid.RowSpan="2">
+                            <GroupBox Header="{DynamicResource SettingsUIHMMHeader}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="2">
                                 <Grid>
-                                    <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"   IsChecked="{Binding CPKREDIR.CheckForUpdates}"    Margin="9,8,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="15"/>
-                                    <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"   IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}" Margin="9,28,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="15"/>
-                                    <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}" IsChecked="{Binding CPKREDIR.CheckForModUpdates}" Margin="9,48,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="15"/>
-                                    <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"     IsChecked="{Binding CPKREDIR.KeepOpen}"           Margin="9,68,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="15"/>
-                                    <Button   Content="{DynamicResource SettingsUIAboutHMM}"                                                          Margin="0,0,10,11" VerticalAlignment="Bottom" HorizontalAlignment="Right" Height="43" Width="185" Click="UI_About_Click"/>
-                                    <Button   Content="{DynamicResource SettingsUICheckHMMUpdate}"                                                    Margin="0,0,10,61" VerticalAlignment="Bottom" HorizontalAlignment="Right" Height="43" Width="185" Click="UI_CheckUpdates"/>
-                                    <Label    Content="{DynamicResource SettingsUIReleaseChannel}"                                                    Margin="4,0,0,78" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" HorizontalContentAlignment="Right"  />
-                                    <ComboBox x:Name="ComboBox_Channel" ItemsSource="{Binding UpdateChannels, Source={x:Static Application.Current}}" SelectedItem="{Binding CurrentChannel, Source={x:Static Application.Current}}" Margin="130,0,0,77" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" Width="200" Height="27" SelectionChanged="ComboBox_Channel_SelectionChanged" />
-                                    <Label    Content="{DynamicResource SettingsUILanguage}"                                                          Margin="4,0,0,45" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" HorizontalContentAlignment="Right"  />
-                                    <ComboBox x:Name="ComboBox_Languages" ItemsSource="{Binding SupportedCultures, Source={x:Static Application.Current}}" SelectedItem="{Binding CurrentCulture, Source={x:Static Application.Current}}" Margin="130,0,0,44" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" Width="200" Height="27" SelectionChanged="ComboBox_Languages_Changed" Loaded="ComboBox_Languages_Loaded" />
-                                    <Label    Content="{DynamicResource SettingsUITheme}"                                                           Margin="4,0,0,12" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" HorizontalContentAlignment="Right"  />
-                                    <ComboBox x:Name="ComboBox_Themes" ItemsSource="{Binding InstalledThemes, Source={x:Static Application.Current}}" SelectedItem="{Binding CurrentTheme, Source={x:Static Application.Current}}" Margin="130,0,0,11" HorizontalAlignment="Left" VerticalAlignment="Bottom" VerticalContentAlignment="Center" Width="200" Height="27" SelectionChanged="ComboBox_Themes_Changed" Loaded="ComboBox_Themes_Loaded" />
+                                    <StackPanel Margin="10,10,0,0">
+                                        <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"   IsChecked="{Binding CPKREDIR.CheckForUpdates}"    Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"   IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}" Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}" IsChecked="{Binding CPKREDIR.CheckForModUpdates}" Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"     IsChecked="{Binding CPKREDIR.KeepOpen}"/>
+                                    </StackPanel>
+
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition/>
+                                            <ColumnDefinition Width="200"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <Grid Margin="6,0,5,10" VerticalAlignment="Bottom">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="32"/>
+                                                <RowDefinition Height="32"/>
+                                                <RowDefinition Height="32"/>
+                                            </Grid.RowDefinitions>
+
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="132"/>
+                                                <ColumnDefinition/>
+                                            </Grid.ColumnDefinitions>
+                                            
+                                            <Label    Content="{DynamicResource SettingsUIReleaseChannel}"        VerticalAlignment="Bottom"/>
+                                            <ComboBox x:Name="ComboBox_Channel"   ItemsSource="{Binding UpdateChannels, Source={x:Static Application.Current}}"    SelectedItem="{Binding CurrentChannel, Source={x:Static Application.Current}}"              Grid.Column="1" VerticalAlignment="Bottom" Height="27" SelectionChanged="ComboBox_Channel_SelectionChanged"/>
+
+                                            <Label    Content="{DynamicResource SettingsUILanguage}" Grid.Row="1" VerticalAlignment="Bottom"/>
+                                            <ComboBox x:Name="ComboBox_Languages" ItemsSource="{Binding SupportedCultures, Source={x:Static Application.Current}}" SelectedItem="{Binding CurrentCulture, Source={x:Static Application.Current}}" Grid.Row="1" Grid.Column="1" VerticalAlignment="Bottom" Height="27" SelectionChanged="ComboBox_Languages_Changed" Loaded="ComboBox_Languages_Loaded"/>
+
+                                            <Label    Content="{DynamicResource SettingsUITheme}"    Grid.Row="2" VerticalAlignment="Bottom"/>
+                                            <ComboBox x:Name="ComboBox_Themes"    ItemsSource="{Binding InstalledThemes, Source={x:Static Application.Current}}"   SelectedItem="{Binding CurrentTheme, Source={x:Static Application.Current}}"   Grid.Row="2" Grid.Column="1" VerticalAlignment="Bottom" Height="27" SelectionChanged="ComboBox_Themes_Changed"    Loaded="ComboBox_Themes_Loaded"/>
+                                        </Grid>
+
+                                        <StackPanel Grid.Column="1" Margin="0,0,10,10" VerticalAlignment="Bottom">
+                                            <Button Content="{DynamicResource SettingsUICheckHMMUpdate}" Height="43" Margin="0,0,0,5" Click="UI_CheckUpdates"/>
+                                            <Button Content="{DynamicResource SettingsUIAboutHMM}"       Height="43" Click="UI_About_Click"/>
+                                        </StackPanel>
+                                    </Grid>
                                 </Grid>
                             </GroupBox>
                         </Grid>
@@ -248,7 +297,7 @@
                 </TabControl>
                 <Grid Grid.Row="1" Background="{DynamicResource HMM.Window.DialogBottom}">
                     <Grid Margin="8,1,8,0" VerticalAlignment="Center" Height="56">
-                        <ComboBox x:Name="ComboBox_GameStatus" ItemsSource="{Binding Games}" Width="260" HorizontalAlignment="Left" Margin="0,8,5,8" SelectionChanged="Game_Changed">
+                        <ComboBox x:Name="ComboBox_GameStatus" ItemsSource="{Binding Games}" Width="280" HorizontalAlignment="Left" Margin="0,8,5,8" SelectionChanged="Game_Changed">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
This PR addresses some issues with the layout of the Settings tab and moves the controls into more convenient layout containers like Grids and StackPanels, rather than having all of the controls floating with a set margin. As well as that, I've redesigned the layout of the Game & Mod Loader group to make it a bit more appealing to look at.

Other minor changes;
- The window size has been increased by 20px.
- The names in the codes list weren't centred vertically - this is now fixed.
- The TextBox style now adds 3px rounded corners.
- The TextBox style for PropertyTools now inherits the global TextBox style, rather than copying and pasting it.

![image](https://user-images.githubusercontent.com/34012267/149395595-e2d36774-39b5-4e68-ad8b-e8238b5c2692.png)
