### PR TITLE
Added code "Fix Homing Trail Position"

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicGenerations.hmm
@@ -425,6 +425,11 @@ WriteNop(0xE5FB17, 6)
 WriteProtected<byte>(0xE5FE10, 0x48)
 WriteProtected<byte>(0xE5FE70, 0x48)
 
+Patch "Fix Homing Trail Position" by "Ahremic"
+WriteProtected<byte>(0xE4F442, 0xF0); // Replaces "UpVector" (0x450), i.e. the floor normal,
+                                      // with "ModelUpVector" (0x4F0), Sonic's actual upward direction.
+                                      // This fixes an actual *bug* where the homing trail position was just WRONG.
+
 Patch "Stomp Keeps Horizontal Velocity" by "TGE"
 string code = @"
 movaps xmm1, [edi+0x290]


### PR DESCRIPTION
Generations erroneously uses the up vector reference used for gameplay input purposes; the one where "up" is relative to the floor. This means if you jump dash while upside-down, the effect will be utterly broken. You can even see this on slopes with the Longer Blue Trail code if you look hard enough. This code fixes this by using the *correct* reference, "Model Up Vector." Names for both fields were gotten from Gens' message system.