### PR TITLE
General UI fixes

### DIFF
--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -158,13 +158,25 @@ namespace HedgeModManager
 
             CodesDatabase.Codes.Sort((x, y) => x.Name.CompareTo(y.Name));
 
-            CodesDatabase.Codes.ForEach((x) =>
+            // Sort enabled codes in alphabetical order.
             {
-                if (x.Enabled)
-                    CodesList.Items.Insert(0, x);
-                else
-                    CodesList.Items.Add(x);
-            });
+                for (int i = CodesDatabase.Codes.Count - 1; i >= 0; i--)
+                {
+                    var code = CodesDatabase.Codes[i];
+
+                    if (code.Enabled)
+                        CodesList.Items.Insert(0, code);
+                }
+
+                CodesDatabase.Codes.ForEach
+                (
+                    (code) =>
+                    {
+                        if (!code.Enabled)
+                            CodesList.Items.Add(code);
+                    }
+                );
+            }
 
             UpdateStatus(LocaliseFormat("StatusUILoadedMods", ModsDatabase.Mods.Count));
             CheckCodeCompatibility();

--- a/HedgeModManager/UI/ModUpdatesInfoView.xaml
+++ b/HedgeModManager/UI/ModUpdatesInfoView.xaml
@@ -32,7 +32,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <Grid>
+        <Grid Margin="-3,2,-3,-4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width=".4*"/>
                 <ColumnDefinition/>
@@ -107,7 +107,7 @@
 
             <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Background="{DynamicResource HMM.Window.DialogBottom}">
                 <DockPanel>
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="4,8">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="8,8">
                         <Button Content="{Binding UpdateText}" Padding="8,0" Margin="0,0,8,0" IsDefault="True"
                                 Command="{Binding UpdateCommand}"/>
 


### PR DESCRIPTION
- Sorted enabled codes alphabetically separate from disabled codes, rather than being Z-A.
- Improved the window margin for the mod updater to match the main window, as there was a border surrounding all of the contents.

Before:
![image](https://user-images.githubusercontent.com/34012267/168185117-6853d08c-f748-4533-8260-91c8188f8f58.png)

After:
![image](https://user-images.githubusercontent.com/34012267/168185376-45c10d0d-df7c-4938-8a59-b6b0e07ffe58.png)