### PR TITLE
Globally enable per-pixel scrolling for ListViews

### DIFF
--- a/HedgeModManager/HedgeApp.xaml
+++ b/HedgeModManager/HedgeApp.xaml
@@ -1387,6 +1387,7 @@
                 <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
                 <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
                 <Setter Property="VerticalContentAlignment" Value="Center"/>
+                <Setter Property="VirtualizingPanel.ScrollUnit" Value="Pixel"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListView}">


### PR DESCRIPTION
Currently when scrolling lists in HMM, WPF scrolls per-item, which can feel a little jarring especially with touch. This small patch switches the scroll unit to pixels, making scrolling feel more fluid.