### PR TITLE
[Sonic Origins] Split Enable Lives code into 3, remove Drop Dash codes [no ci]

### DIFF
--- a/HedgeModManager/Resources/Codesv2/SonicOrigins.hmm
+++ b/HedgeModManager/Resources/Codesv2/SonicOrigins.hmm
@@ -30,59 +30,48 @@ if (rsdkGlobals == 0)
     var result = ScanSignature("\x48\x8B\x05\x00\x00\x00\x00\x8B\x80\x00\x00\x00\x00\x85\xC0\x78\x2D\x83\xF8\x01\x7E\x1F\x83\xF8\x02\x74\x11\x83\xC0\xFC\x83\xF8\x02\x77\x1B\x48\x8D\x0D\x00\x00\x00\x00\xEB\x19\x48\x8D\x0D\x00\x00\x00\x00\xEB\x10\x48\x8D\x0D\x00\x00\x00\x00\xEB\x07\x48\x8D\x0D\x00\x00\x00\x00\x48\x8B\x05\x00\x00\x00\x00\xB2\x02\x4C\x8B\x80\x00\x00\x00\x00\x41\xFF\xD0\x48\x8B\x0D\x00\x00\x00\x00\x66\x89\x41\x04",
     "xxx????xx????xxxxxxxxxxxxxxxxxxxxxxxxx????xxxxx????xxxxx????xxxxx????xxx????xxxxx????xxxxxx????xxxx");
     rsdkGlobals = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
-    Console.WriteLine(rsdkGlobals);
     return;
 }
 
-// Sonic 1 Coin Mode
-WriteProtected<byte>(rsdkV4Flags + 0x1F4, 0x00);
+// Check if Sonic 1 game.playMode is set to BOOT_PLAYMODE_ANNIVERSARY
+if (*(byte*)(rsdkV4Flags + 0x1A4) == 1)
+{
+    // Sonic 1 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x1F4, 0x00);
+}
 
-// Sonic 2 Coin Mode
-WriteProtected<byte>(rsdkV4Flags + 0x288, 0x00);
+// Check if Sonic 2 game.playMode is set to BOOT_PLAYMODE_ANNIVERSARY
+if (*(byte*)(rsdkV4Flags + 0x23C) == 1)
+{
+    // Sonic 2 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x288, 0x00);
+}
 
-// Sonic CD Coin Mode
-WriteProtected<byte>(rsdkV3Flags + 0x220, 0x00);
+// Check if rsdkV3 game.playMode is set to BOOT_PLAYMODE_ANNIVERSARY
+if (*(byte*)(rsdkV3Flags + 0x1DC) == 1)
+{
+    // Sonic CD Coin Mode
+    WriteProtected<byte>(rsdkV3Flags + 0x220, 0x00);
+}
 
 // Sonic 3&K Coin Mode and HUD Update
 if (*(long*)rsdkGlobals != 0)
 {
-    // HUD Update
-    WriteProtected<byte>(*(long*)rsdkGlobals + 0x447D20, 0x00);
+    // Check if game.playMode is set to BOOT_PLAYMODE_ANNIVERSARY
+    if (*(byte*)(*(long*)rsdkGlobals + 0x447D08) == 1)
+    {
+        // HUD Update
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447D20, 0x00);
 
-    // Coin Mode
-    WriteProtected<byte>(*(long*)rsdkGlobals + 0x447CD4, 0x00);
+        // Coin Mode
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447CD4, 0x00);
+    }
 }
 
-Code "Disable Drop Dash in Sonic 1's Anniversary Mode" by "ĐeäTh"
-static long rsdkV4Flags;
-
-if (rsdkV4Flags == 0)
-{
-    var result = ScanSignature("\x4C\x8D\x35\x00\x00\x00\x00\x4C\x89\x7C\x24\x00\x4C\x8D\x3D\x00\x00\x00\x00\x66\x66\x0F\x1F\x84\x00\x00\x00\x00\x00\x48\x63\xD3\x48\x8B\xCD\x48\xC1\xE2\x05\x49\x03\xD7\xE8\x00\x00\x00\x00\x3C\x01\x75\x0B\xBB\x00\x00\x00\x00\x41\x89\x34\xBE\x8B\xFB\x0F\xB6\x05\x00\x00\x00\x00\xFF\xC3\x48\xFF\xC7\x3B\xD8\x7C\xCF\x4C\x8B\x7C\x24\x00\x4C\x8B\x74\x24\x00\x48\x8B\x7C\x24\x00\x48\x83\xC4\x20\x5E\x5D\x5B\xC3",
-        "xxx????xxxx?xxx????xxxxxx????xxxxxxxxxxxxxx????xxxxx????xxxxxxxxx????xxxxxxxxxxxxx?xxxx?xxxx?xxxxxxxx");
-    rsdkV4Flags = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
-    return;
-}
-
-// Sonic 1 Drop Dash
-WriteProtected<byte>(rsdkV4Flags + 0x1A4, 0x00);
-
-Code "Disable Drop Dash in Sonic 2's Anniversary Mode" by "ĐeäTh"
-static long rsdkV4Flags;
-
-if (rsdkV4Flags == 0)
-{
-    var result = ScanSignature("\x4C\x8D\x35\x00\x00\x00\x00\x4C\x89\x7C\x24\x00\x4C\x8D\x3D\x00\x00\x00\x00\x66\x66\x0F\x1F\x84\x00\x00\x00\x00\x00\x48\x63\xD3\x48\x8B\xCD\x48\xC1\xE2\x05\x49\x03\xD7\xE8\x00\x00\x00\x00\x3C\x01\x75\x0B\xBB\x00\x00\x00\x00\x41\x89\x34\xBE\x8B\xFB\x0F\xB6\x05\x00\x00\x00\x00\xFF\xC3\x48\xFF\xC7\x3B\xD8\x7C\xCF\x4C\x8B\x7C\x24\x00\x4C\x8B\x74\x24\x00\x48\x8B\x7C\x24\x00\x48\x83\xC4\x20\x5E\x5D\x5B\xC3",
-        "xxx????xxxx?xxx????xxxxxx????xxxxxxxxxxxxxx????xxxxx????xxxxxxxxx????xxxxxxxxxxxxx?xxxx?xxxx?xxxxxxxx");
-    rsdkV4Flags = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
-    return;
-}
-
-// Sonic 2 Drop Dash
-WriteProtected<byte>(rsdkV4Flags + 0x23C, 0x00);
-
-Code "Disable Drop Dash in Sonic CD's Anniversary Mode" by "ĐeäTh"
+Code "Enable Lives in Mirror Mode" by "ĐeäTh"
 static long rsdkV3Flags;
+static long rsdkV4Flags;
+static long rsdkGlobals;
 
 if (rsdkV3Flags == 0)
 {
@@ -92,23 +81,117 @@ if (rsdkV3Flags == 0)
     return;
 }
 
-// Sonic CD Drop Dash
-WriteProtected<byte>(rsdkV3Flags + 0x1DC, 0x00);
-
-Code "Disable Drop Dash in Sonic 3 & Knuckles's Anniversary Mode" by "ĐeäTh"
-static long rsdkGlobals;
+if (rsdkV4Flags == 0)
+{
+    var result = ScanSignature("\x4C\x8D\x35\x00\x00\x00\x00\x4C\x89\x7C\x24\x00\x4C\x8D\x3D\x00\x00\x00\x00\x66\x66\x0F\x1F\x84\x00\x00\x00\x00\x00\x48\x63\xD3\x48\x8B\xCD\x48\xC1\xE2\x05\x49\x03\xD7\xE8\x00\x00\x00\x00\x3C\x01\x75\x0B\xBB\x00\x00\x00\x00\x41\x89\x34\xBE\x8B\xFB\x0F\xB6\x05\x00\x00\x00\x00\xFF\xC3\x48\xFF\xC7\x3B\xD8\x7C\xCF\x4C\x8B\x7C\x24\x00\x4C\x8B\x74\x24\x00\x48\x8B\x7C\x24\x00\x48\x83\xC4\x20\x5E\x5D\x5B\xC3",
+        "xxx????xxxx?xxx????xxxxxx????xxxxxxxxxxxxxx????xxxxx????xxxxxxxxx????xxxxxxxxxxxxx?xxxx?xxxx?xxxxxxxx");
+    rsdkV4Flags = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
+    return;
+}
 
 if (rsdkGlobals == 0)
 {
     var result = ScanSignature("\x48\x8B\x05\x00\x00\x00\x00\x8B\x80\x00\x00\x00\x00\x85\xC0\x78\x2D\x83\xF8\x01\x7E\x1F\x83\xF8\x02\x74\x11\x83\xC0\xFC\x83\xF8\x02\x77\x1B\x48\x8D\x0D\x00\x00\x00\x00\xEB\x19\x48\x8D\x0D\x00\x00\x00\x00\xEB\x10\x48\x8D\x0D\x00\x00\x00\x00\xEB\x07\x48\x8D\x0D\x00\x00\x00\x00\x48\x8B\x05\x00\x00\x00\x00\xB2\x02\x4C\x8B\x80\x00\x00\x00\x00\x41\xFF\xD0\x48\x8B\x0D\x00\x00\x00\x00\x66\x89\x41\x04",
     "xxx????xx????xxxxxxxxxxxxxxxxxxxxxxxxx????xxxxx????xxxxx????xxxxx????xxx????xxxxx????xxxxxx????xxxx");
     rsdkGlobals = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
-    Console.WriteLine(rsdkGlobals);
     return;
 }
 
-// Sonic 3&K Drop Dash
+// Check if Sonic 1 game.playMode is set to BOOT_PLAYMODE_MIRRORING
+if (*(byte*)(rsdkV4Flags + 0x1A4) == 3)
+{
+    // Sonic 1 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x1F4, 0x00);
+}
+
+// Check if Sonic 2 game.playMode is set to BOOT_PLAYMODE_MIRRORING
+if (*(byte*)(rsdkV4Flags + 0x23C) == 3)
+{
+    // Sonic 2 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x288, 0x00);
+}
+
+// Check if rsdkV3 game.playMode is set to BOOT_PLAYMODE_MIRRORING
+if (*(byte*)(rsdkV3Flags + 0x1DC) == 3)
+{
+    // Sonic CD Coin Mode
+    WriteProtected<byte>(rsdkV3Flags + 0x220, 0x00);
+}
+
+// Sonic 3&K Coin Mode and HUD Update
 if (*(long*)rsdkGlobals != 0)
 {
-    WriteProtected<byte>(*(long*)rsdkGlobals + 0x447D08, 0x00);
+    // Check if game.playMode is set to BOOT_PLAYMODE_MIRRORING
+    if (*(byte*)(*(long*)rsdkGlobals + 0x447D08) == 3)
+    {
+        // HUD Update
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447D20, 0x00);
+
+        // Coin Mode
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447CD4, 0x00);
+    }
+}
+
+Code "Enable Lives in Story Mode" by "ĐeäTh"
+static long rsdkV3Flags;
+static long rsdkV4Flags;
+static long rsdkGlobals;
+
+if (rsdkV3Flags == 0)
+{
+    var result = ScanSignature("\x48\x63\xFB\x48\x8B\xCE\x48\x8B\xD7\x48\xC1\xE2\x05\x49\x03\xD6\xE8\x00\x00\x00\x00\x3C\x01\x74\x2D\x0F\xB6\x05\x00\x00\x00\x00\xFF\xC3\x3B\xD8\x7C\xDA\xB8\x00\x00\x00\x00\x48\x8B\x5C\x24\x00\x48\x8B\x6C\x24\x00\x48\x8B\x74\x24\x00\x48\x8B\x7C\x24\x00\x48\x83\xC4\x20\x41\x5E\xC3\x48\x8D\x05\x00\x00\x00\x00\x89\x2C\xB8\x8B\xC3\xEB\xD7",
+    "xxxxxxxxxxxxxxxxx????xxxxxxx????xxxxxxx????xxxx?xxxx?xxxx?xxxx?xxxxxxxxxx????xxxxxxx") + 0x46;
+    rsdkV3Flags = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
+    return;
+}
+
+if (rsdkV4Flags == 0)
+{
+    var result = ScanSignature("\x4C\x8D\x35\x00\x00\x00\x00\x4C\x89\x7C\x24\x00\x4C\x8D\x3D\x00\x00\x00\x00\x66\x66\x0F\x1F\x84\x00\x00\x00\x00\x00\x48\x63\xD3\x48\x8B\xCD\x48\xC1\xE2\x05\x49\x03\xD7\xE8\x00\x00\x00\x00\x3C\x01\x75\x0B\xBB\x00\x00\x00\x00\x41\x89\x34\xBE\x8B\xFB\x0F\xB6\x05\x00\x00\x00\x00\xFF\xC3\x48\xFF\xC7\x3B\xD8\x7C\xCF\x4C\x8B\x7C\x24\x00\x4C\x8B\x74\x24\x00\x48\x8B\x7C\x24\x00\x48\x83\xC4\x20\x5E\x5D\x5B\xC3",
+        "xxx????xxxx?xxx????xxxxxx????xxxxxxxxxxxxxx????xxxxx????xxxxxxxxx????xxxxxxxxxxxxx?xxxx?xxxx?xxxxxxxx");
+    rsdkV4Flags = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
+    return;
+}
+
+if (rsdkGlobals == 0)
+{
+    var result = ScanSignature("\x48\x8B\x05\x00\x00\x00\x00\x8B\x80\x00\x00\x00\x00\x85\xC0\x78\x2D\x83\xF8\x01\x7E\x1F\x83\xF8\x02\x74\x11\x83\xC0\xFC\x83\xF8\x02\x77\x1B\x48\x8D\x0D\x00\x00\x00\x00\xEB\x19\x48\x8D\x0D\x00\x00\x00\x00\xEB\x10\x48\x8D\x0D\x00\x00\x00\x00\xEB\x07\x48\x8D\x0D\x00\x00\x00\x00\x48\x8B\x05\x00\x00\x00\x00\xB2\x02\x4C\x8B\x80\x00\x00\x00\x00\x41\xFF\xD0\x48\x8B\x0D\x00\x00\x00\x00\x66\x89\x41\x04",
+    "xxx????xx????xxxxxxxxxxxxxxxxxxxxxxxxx????xxxxx????xxxxx????xxxxx????xxx????xxxxx????xxxxxx????xxxx");
+    rsdkGlobals = (long)result + *((int*)IntPtr.Add(new IntPtr(result), 3)) + 7;
+    return;
+}
+
+// Check if Sonic 1 game.playMode is set to BOOT_PLAYMODE_STORY
+if (*(byte*)(rsdkV4Flags + 0x1A4) == 5)
+{
+    // Sonic 1 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x1F4, 0x00);
+}
+
+// Check if Sonic 2 game.playMode is set to BOOT_PLAYMODE_STORY
+if (*(byte*)(rsdkV4Flags + 0x23C) == 5)
+{
+    // Sonic 2 Coin Mode
+    WriteProtected<byte>(rsdkV4Flags + 0x288, 0x00);
+}
+
+// Check if rsdkV3 game.playMode is set to BOOT_PLAYMODE_STORY
+if (*(byte*)(rsdkV3Flags + 0x1DC) == 5)
+{
+    // Sonic CD Coin Mode
+    WriteProtected<byte>(rsdkV3Flags + 0x220, 0x00);
+}
+
+// Sonic 3&K Coin Mode and HUD Update
+if (*(long*)rsdkGlobals != 0)
+{
+    // Check if game.playMode is set to BOOT_PLAYMODE_STORY
+    if (*(byte*)(*(long*)rsdkGlobals + 0x447D08) == 5)
+    {
+        // HUD Update
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447D20, 0x00);
+
+        // Coin Mode
+        WriteProtected<byte>(*(long*)rsdkGlobals + 0x447CD4, 0x00);
+    }
 }


### PR DESCRIPTION
- Added more guards for the Enable Lives codes which made it turn into 3 codes, separating Anniversary, Mirror and Story mode.
- Removed Drop Dash codes due to the not working properly.