### PR TITLE
Fix issues regarding moving the game directory

### DIFF
--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -224,7 +224,8 @@ namespace HedgeModManager
             if (GameInstalls.Count == 0)
                 GameInstalls.Add(new GameInstall(Games.Unknown, null, GameLauncher.None));
 
-            if (string.IsNullOrEmpty(ModsDbPath) && !string.IsNullOrEmpty(StartDirectory))
+            bool modsDbValidPath = !string.IsNullOrEmpty(ModsDbPath) && Directory.Exists(ModsDbPath);
+            if (!modsDbValidPath && !string.IsNullOrEmpty(StartDirectory))
                 ModsDbPath = Path.Combine(StartDirectory, "Mods");
             if (!string.IsNullOrEmpty(StartDirectory))
                 ConfigPath = Path.Combine(StartDirectory, "cpkredir.ini");
@@ -701,7 +702,12 @@ namespace HedgeModManager
                 {
                     ConfigPath = Path.Combine(StartDirectory, "cpkredir.ini");
                     Config = new CPKREDIRConfig(ConfigPath);
+
                     ModsDbPath = Path.Combine(StartDirectory, Path.GetDirectoryName(Config.ModsDbIni) ?? "Mods");
+                    if (!Directory.Exists(ModsDbPath))
+                    {
+                        ModsDbPath = Path.Combine(StartDirectory, "Mods");
+                    }
                 }
             }
             catch (UnauthorizedAccessException)

--- a/HedgeModManager/ModsDB.cs
+++ b/HedgeModManager/ModsDB.cs
@@ -232,7 +232,7 @@ namespace HedgeModManager
             if (modPair.Key == null)
                 return null;
 
-            return Mods.FirstOrDefault(t => Path.GetDirectoryName(modPair.Value) == t.RootDirectory);
+            return Mods.FirstOrDefault(t => Path.GetDirectoryName(modPair.Value).Equals(t.RootDirectory, StringComparison.OrdinalIgnoreCase));
         }
 
         public void DeleteMod(ModInfo mod)

--- a/HedgeModManager/ModsDB.cs
+++ b/HedgeModManager/ModsDB.cs
@@ -58,6 +58,12 @@ namespace HedgeModManager
                     using (var stream = File.OpenRead(iniPath))
                         IniSerializer.Deserialize(this, stream);
 
+                    // Read relative mod paths as full paths
+                    foreach(var modGuid in mMods.Keys.ToList())
+                    {
+                        mMods[modGuid] = MakeModPathFull(mMods[modGuid]);
+                    }
+
                     // Force load order to bottom to top
                     ReverseLoadOrder = false;
                 }
@@ -197,6 +203,8 @@ namespace HedgeModManager
                 if (mod.Favorite)
                     FavoriteMods.Add(id);
 
+                mod.RootDirectory = MakeModPathRelative(mod.RootDirectory);
+
                 // ReSharper disable once AssignNullToNotNullAttribute
                 mMods.Add(id, $"{mod.RootDirectory}{Path.DirectorySeparatorChar}mod.ini");
             }
@@ -223,6 +231,18 @@ namespace HedgeModManager
 
                 await CodeProvider.CompileCodes(codes, CodeProvider.CompiledCodesPath);
             }
+        }
+
+        public string MakeModPathRelative(string modPath)
+        {
+            // Returns mod directory as folder name only.
+            return Path.GetFileName(modPath);
+        }
+
+        public string MakeModPathFull(string modPath)
+        {
+            // Converts the relative directory into a full path based on the database location
+            return Path.Combine(RootDirectory, modPath);
         }
 
         public ModInfo GetModFromActiveGUID(string id)


### PR DESCRIPTION
- Makes path comparison ignore case (used when detecting enabled mods)
- Checks for the existence of the mods path before assuming it is correct, and uses the default one if not