### PR TITLE
[UI] Implemented tree list view for codes

### DIFF
--- a/HedgeModManager/Config/RegistryConfig.cs
+++ b/HedgeModManager/Config/RegistryConfig.cs
@@ -12,12 +12,14 @@ namespace HedgeModManager
         private const string PersonalizePath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 
         public static string ConfigPath { get; } = @"SOFTWARE\HEDGEMM";
-        public static string LastGameDirectory;
+        public static string LastGame;
         public static string ExtraGameDirectories;
         public static string UILanguage;
         public static string UITheme;
 
         public static int CodesSortingColumnIndex = 1;
+
+        public static bool CodesUseTreeView = true;
 
         static RegistryConfig()
         {
@@ -27,11 +29,12 @@ namespace HedgeModManager
         public static void Save()
         {
             var key = Registry.CurrentUser.CreateSubKey(ConfigPath);
-            key.SetValue("LastGame", LastGameDirectory);
-            key.SetValue("ExtraGameDirectories", ExtraGameDirectories);
-            key.SetValue("UILanguage", UILanguage);
-            key.SetValue("UITheme", UITheme);
-            key.SetValue("CodesSortingColumnIndex", CodesSortingColumnIndex);
+            key.SetValue(nameof(LastGame), LastGame);
+            key.SetValue(nameof(ExtraGameDirectories), ExtraGameDirectories);
+            key.SetValue(nameof(UILanguage), UILanguage);
+            key.SetValue(nameof(UITheme), UITheme);
+            key.SetValue(nameof(CodesSortingColumnIndex), CodesSortingColumnIndex);
+            key.SetValue(nameof(CodesUseTreeView), CodesUseTreeView ? 1 : 0);
             key.Close();
         }
 
@@ -50,11 +53,12 @@ namespace HedgeModManager
             }
 
             var key = Registry.CurrentUser.CreateSubKey(ConfigPath);
-            LastGameDirectory = (string)key.GetValue("LastGame", string.Empty);
-            ExtraGameDirectories = (string)key.GetValue("ExtraGameDirectories", string.Empty);
-            UILanguage = (string)key.GetValue("UILanguage", HedgeApp.PCCulture);
-            UITheme = (string)key.GetValue("UITheme", useLightMode ? "LightTheme" : "DarkerTheme");
-            CodesSortingColumnIndex = (int)key.GetValue("CodesSortingColumnIndex", 1);
+            LastGame                = (string)key.GetValue(nameof(LastGame), string.Empty);
+            ExtraGameDirectories    = (string)key.GetValue(nameof(ExtraGameDirectories), string.Empty);
+            UILanguage              = (string)key.GetValue(nameof(UILanguage), HedgeApp.PCCulture);
+            UITheme                 = (string)key.GetValue(nameof(UITheme), useLightMode ? "LightTheme" : "DarkerTheme");
+            CodesSortingColumnIndex = (int)key.GetValue(nameof(CodesSortingColumnIndex), 1);
+            CodesUseTreeView        = (int)key.GetValue(nameof(CodesUseTreeView), 1) != 0;
             key.Close();
         }
     }

--- a/HedgeModManager/Config/RegistryConfig.cs
+++ b/HedgeModManager/Config/RegistryConfig.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace HedgeModManager
 {
@@ -12,7 +7,7 @@ namespace HedgeModManager
         private const string PersonalizePath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 
         public static string ConfigPath { get; } = @"SOFTWARE\HEDGEMM";
-        public static string LastGame;
+        public static string LastGameDirectory;
         public static string ExtraGameDirectories;
         public static string UILanguage;
         public static string UITheme;
@@ -29,7 +24,7 @@ namespace HedgeModManager
         public static void Save()
         {
             var key = Registry.CurrentUser.CreateSubKey(ConfigPath);
-            key.SetValue(nameof(LastGame), LastGame);
+            key.SetValue("LastGame", LastGameDirectory);
             key.SetValue(nameof(ExtraGameDirectories), ExtraGameDirectories);
             key.SetValue(nameof(UILanguage), UILanguage);
             key.SetValue(nameof(UITheme), UITheme);
@@ -53,7 +48,7 @@ namespace HedgeModManager
             }
 
             var key = Registry.CurrentUser.CreateSubKey(ConfigPath);
-            LastGame                = (string)key.GetValue(nameof(LastGame), string.Empty);
+            LastGameDirectory       = (string)key.GetValue("LastGame", string.Empty);
             ExtraGameDirectories    = (string)key.GetValue(nameof(ExtraGameDirectories), string.Empty);
             UILanguage              = (string)key.GetValue(nameof(UILanguage), HedgeApp.PCCulture);
             UITheme                 = (string)key.GetValue(nameof(UITheme), useLightMode ? "LightTheme" : "DarkerTheme");

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -213,9 +213,9 @@ namespace HedgeModManager
             GameInstalls = GameInstall.SearchForGames();
             if (FindAndSetLocalGame() == null)
             {
-                if (!string.IsNullOrEmpty(RegistryConfig.LastGameDirectory) && CurrentGame == Games.Unknown)
+                if (!string.IsNullOrEmpty(RegistryConfig.LastGame) && CurrentGame == Games.Unknown)
                 {
-                    StartDirectory = RegistryConfig.LastGameDirectory;
+                    StartDirectory = RegistryConfig.LastGame;
                     FindAndSetLocalGame();
                 }
             }

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -213,9 +213,9 @@ namespace HedgeModManager
             GameInstalls = GameInstall.SearchForGames();
             if (FindAndSetLocalGame() == null)
             {
-                if (!string.IsNullOrEmpty(RegistryConfig.LastGame) && CurrentGame == Games.Unknown)
+                if (!string.IsNullOrEmpty(RegistryConfig.LastGameDirectory) && CurrentGame == Games.Unknown)
                 {
-                    StartDirectory = RegistryConfig.LastGame;
+                    StartDirectory = RegistryConfig.LastGameDirectory;
                     FindAndSetLocalGame();
                 }
             }
@@ -347,7 +347,7 @@ namespace HedgeModManager
                     CurrentGameInstall = steamGame;
                     try
                     {
-                        RegistryConfig.LastGame = StartDirectory;
+                        RegistryConfig.LastGameDirectory = StartDirectory;
                         RegistryConfig.Save();
                         ConfigPath = Path.Combine(StartDirectory, "cpkredir.ini");
                         Config = new CPKREDIRConfig(ConfigPath);
@@ -577,7 +577,7 @@ namespace HedgeModManager
                     CurrentGame = game;
                     CurrentGameInstall = gameinstall;
                     StartDirectory = gameinstall.GameDirectory;
-                    RegistryConfig.LastGame = StartDirectory;
+                    RegistryConfig.LastGameDirectory = StartDirectory;
                     RegistryConfig.Save();
                 }
             }

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -347,7 +347,7 @@ namespace HedgeModManager
                     CurrentGameInstall = steamGame;
                     try
                     {
-                        RegistryConfig.LastGameDirectory = StartDirectory;
+                        RegistryConfig.LastGame = StartDirectory;
                         RegistryConfig.Save();
                         ConfigPath = Path.Combine(StartDirectory, "cpkredir.ini");
                         Config = new CPKREDIRConfig(ConfigPath);
@@ -577,7 +577,7 @@ namespace HedgeModManager
                     CurrentGame = game;
                     CurrentGameInstall = gameinstall;
                     StartDirectory = gameinstall.GameDirectory;
-                    RegistryConfig.LastGameDirectory = StartDirectory;
+                    RegistryConfig.LastGame = StartDirectory;
                     RegistryConfig.Save();
                 }
             }

--- a/HedgeModManager/Languages/en-AU.xaml
+++ b/HedgeModManager/Languages/en-AU.xaml
@@ -69,6 +69,9 @@
     <system:String x:Key="CodesUIInfo"    >Double-click this code for more information.</system:String>
     <system:String x:Key="CodesUIInfoHint">Hover over a code for more information.</system:String>
     <system:String x:Key="CodesUINoInfo"  >No information available.</system:String>
+    <system:String x:Key="CodesUIExpand"  >Expand All</system:String>
+    <system:String x:Key="CodesUICollapse">Collapse All</system:String>
+    <system:String x:Key="CodesUINullCategory">Uncategorised</system:String>
     <system:String xml:space="preserve" x:Key="CodesUIVersionIncompatible">The installed codes are incompatible with the code loader.&#x0a;Please update the codes and the code loader.&#x0a;WARNING: This will erase any custom codes.</system:String>
     <system:String xml:space="preserve" x:Key="CodesUIFetching">Fetching codes...</system:String>
 
@@ -88,16 +91,17 @@
     <system:String x:Key="SettingsUILabelProfile"   >Profile:</system:String>
     <system:String x:Key="SettingsUILabelMDir"      >Mods Directory:</system:String>
     <!--   Hedge Mod Manager -->
-    <system:String x:Key="SettingsUIHMMHeader"      >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"  >Check for mod loader updates</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"  >Check for code loader updates</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates">Check for mod updates</system:String>
-    <system:String x:Key="SettingsUIKeepHMMOpen"    >Keep Hedge Mod Manager open after starting a game</system:String>
-    <system:String x:Key="SettingsUICheckHMMUpdate" >Check for Updates</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"       >About Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUILanguage"       >Language:</system:String>
-    <system:String x:Key="SettingsUITheme"          >Theme:</system:String>
-    <system:String x:Key="SettingsUIReleaseChannel" >Update Channel:</system:String>
+    <system:String x:Key="SettingsUIHMMHeader"       >Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"   >Check for mod loader updates</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"   >Check for code loader updates</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates" >Check for mod updates</system:String>
+    <system:String x:Key="SettingsUIKeepHMMOpen"     >Keep Hedge Mod Manager open after starting a game</system:String>
+    <system:String x:Key="SettingsUICodesUseTreeView">Use tree view for codes list</system:String>
+    <system:String x:Key="SettingsUICheckHMMUpdate"  >Check for Updates</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"        >About Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUILanguage"        >Language:</system:String>
+    <system:String x:Key="SettingsUITheme"           >Theme:</system:String>
+    <system:String x:Key="SettingsUIReleaseChannel"  >Update Channel:</system:String>
     <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
     <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
     <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>

--- a/HedgeModManager/Languages/en-US.xaml
+++ b/HedgeModManager/Languages/en-US.xaml
@@ -69,6 +69,9 @@
     <system:String x:Key="CodesUIInfo"    >Double-click this code for more information.</system:String>
     <system:String x:Key="CodesUIInfoHint">Hover over a code for more information.</system:String>
     <system:String x:Key="CodesUINoInfo"  >No information available.</system:String>
+    <system:String x:Key="CodesUIExpand"  >Expand All</system:String>
+    <system:String x:Key="CodesUICollapse">Collapse All</system:String>
+    <system:String x:Key="CodesUINullCategory">Uncategorized</system:String>
     <system:String xml:space="preserve" x:Key="CodesUIVersionIncompatible">The installed codes are incompatible with the code loader.&#x0a;Please update the codes and the code loader.&#x0a;WARNING: This will erase any custom codes.</system:String>
     <system:String xml:space="preserve" x:Key="CodesUIFetching">Fetching codes...</system:String>
 
@@ -88,16 +91,17 @@
     <system:String x:Key="SettingsUILabelProfile"   >Profile:</system:String>
     <system:String x:Key="SettingsUILabelMDir"      >Mods Directory:</system:String>
     <!--   Hedge Mod Manager -->
-    <system:String x:Key="SettingsUIHMMHeader"      >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"  >Check for mod loader updates</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"  >Check for code loader updates</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates">Check for mod updates</system:String>
-    <system:String x:Key="SettingsUIKeepHMMOpen"    >Keep Hedge Mod Manager open after starting a game</system:String>
-    <system:String x:Key="SettingsUICheckHMMUpdate" >Check for Updates</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"       >About Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUILanguage"       >Language:</system:String>
-    <system:String x:Key="SettingsUITheme"          >Theme:</system:String>
-    <system:String x:Key="SettingsUIReleaseChannel" >Update Channel:</system:String>
+    <system:String x:Key="SettingsUIHMMHeader"       >Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"   >Check for mod loader updates</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"   >Check for code loader updates</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates" >Check for mod updates</system:String>
+    <system:String x:Key="SettingsUIKeepHMMOpen"     >Keep Hedge Mod Manager open after starting a game</system:String>
+    <system:String x:Key="SettingsUICodesUseTreeView">Use tree view for codes list</system:String>
+    <system:String x:Key="SettingsUICheckHMMUpdate"  >Check for Updates</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"        >About Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUILanguage"        >Language:</system:String>
+    <system:String x:Key="SettingsUITheme"           >Theme:</system:String>
+    <system:String x:Key="SettingsUIReleaseChannel"  >Update Channel:</system:String>
     <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
     <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
     <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>

--- a/HedgeModManager/UI/Converters.cs
+++ b/HedgeModManager/UI/Converters.cs
@@ -124,6 +124,27 @@ namespace HedgeModManager
         }
     }
 
+
+    [ValueConversion(typeof(bool), typeof(Visibility))]
+    public class InverseBoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not bool)
+                return Visibility.Collapsed;
+
+            return (bool)value ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not Visibility)
+                throw new ArgumentException("Invalid argument");
+
+            return (Visibility)value == Visibility.Collapsed;
+        }
+    }
+
     [ValueConversion(typeof(bool), typeof(Visibility))]
     public class BoolToVisibilityConverterLinux : IValueConverter
     {

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -180,7 +180,7 @@
                                         <ColumnDefinition Name="CodesTreeDescriptionColumn" Width="225" MinWidth="225"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <TreeView x:Name="CodesTree" BorderThickness="0" Margin="0,2,2,0" PreviewKeyDown="CodesList_OnPreviewKeyDown"
+                                    <TreeView x:Name="CodesTree" BorderThickness="0" Margin="0,2,1,0" PreviewKeyDown="CodesList_OnPreviewKeyDown"
                                               ContextMenu="{DynamicResource CodesTreeContextMenu}" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                                         <TreeView.Resources>
                                             <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -12,6 +12,7 @@
         MinHeight="640" MinWidth="580" Height="640" Width="580" WindowStartupLocation="CenterScreen" Style="{StaticResource HedgeWindow}">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
         <local:BoolToYesNoConverter x:Key="BoolToYesNoConverter"/>
         <local:BoolToBrushConverter x:Key="BoolToBrushConverter"/>
         <local:ModUpdateToBrushConverter x:Key="ModUpdateToBrushConverter"/>
@@ -26,6 +27,10 @@
             <MenuItem Header="{DynamicResource ModsUIModDelete}" Click="UI_RemoveMod_Click" InputGestureText="(Delete)"/>
             <MenuItem x:Name="ContextMenuItemCheckUpdateAll" Header="{DynamicResource ModsUICheckUpdatesAll}" Click="UI_CheckUpdates_AllMods"/>
         </ContextMenu>
+        <ContextMenu x:Key="CodesTreeContextMenu">
+            <MenuItem Header="{DynamicResource CodesUIExpand}"   Click="UI_CodesTree_ExpandAll_Click"/>
+            <MenuItem Header="{DynamicResource CodesUICollapse}" Click="UI_CodesTree_CollapseAll_Click"/>
+        </ContextMenu>
     </Window.Resources>
     <Grid>
         <Grid Margin="-3,2,-3,-4">
@@ -34,7 +39,9 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
+                
                 <TextBlock x:Name="StatusLbl" Margin="175,2,4,4" FontSize="12" TextAlignment="Right" HorizontalAlignment="Stretch" VerticalAlignment="Top"/>
+                
                 <TabControl x:Name="MainTabControl" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" Margin="-2,0,-2,5" SelectionChanged="MainTabControl_SelectionChanged">
                     <TabItem x:Name="ModsTab" Header="{DynamicResource MainUIMods}">
                         <Grid>
@@ -154,6 +161,7 @@
                             </Border>
                         </Grid>
                     </TabItem>
+                    
                     <TabItem x:Name="CodesTab" Header="{DynamicResource MainUICodes}" Selector.Selected="UI_CodesTab_Click" Margin="1,0,-1,0">
                         <Grid>
                             <GroupBox Margin="10,5,10,5" Style="{StaticResource RoundBorder}">
@@ -165,11 +173,100 @@
                                 </Grid>
                             </GroupBox>
                             <Grid>
-                                <Grid Margin="10,5,10,41">
+                                <Grid Name="CodesTreeContainer" Margin="10,5,10,41" Visibility="Collapsed">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Name="CodesTreeDescriptionColumn" Width="225" MinWidth="225"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <TreeView x:Name="CodesTree" BorderThickness="0" Margin="0,2,2,0" PreviewKeyDown="CodesList_OnPreviewKeyDown"
+                                              ContextMenu="{DynamicResource CodesTreeContextMenu}" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                        <TreeView.Resources>
+                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
+                                                             Color="{DynamicResource HMM.Button.HoverColor}"/>
+                                            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"
+                                                             Color="{DynamicResource HMM.Button.HoverColor}" />
+                                        </TreeView.Resources>
+                                        <TreeView.ItemContainerStyle>
+                                            <Style TargetType="{x:Type TreeViewItem}">
+                                                <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                                                <EventSetter Event="RequestBringIntoView" Handler="CodesTree_ViewItem_RequestBringIntoView"/>
+                                            </Style>
+                                        </TreeView.ItemContainerStyle>
+                                        <TreeView.ItemTemplate>
+                                            <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                                                <HierarchicalDataTemplate.ItemContainerStyle>
+                                                    <Style TargetType="{x:Type TreeViewItem}">
+                                                        <Setter Property="ToolTipService.ToolTip">
+                                                            <Setter.Value>
+                                                                <ToolTip Content="{DynamicResource CodesUIInfo}" Tag="{Binding Path=Code.Description}">
+                                                                    <ToolTip.Style>
+                                                                        <Style TargetType="ToolTip" BasedOn="{StaticResource {x:Type ToolTip}}">
+                                                                            <Style.Triggers>
+                                                                                <Trigger Property="Tag" Value="{x:Static sys:String.Empty}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                </Trigger>
+                                                                                <Trigger Property="Tag" Value="{x:Null}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                </Trigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </ToolTip.Style>
+                                                                </ToolTip>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                        <EventSetter Event="MouseDoubleClick" Handler="CodesList_MouseDoubleClick"/>
+                                                        <EventSetter Event="MouseEnter"       Handler="CodesView_MouseEnter"/>
+                                                        <EventSetter Event="MouseLeave"       Handler="CodesView_MouseLeave"/>
+                                                        <EventSetter Event="Selected"         Handler="CodesView_ViewItem_Selected"/>
+                                                    </Style>
+                                                </HierarchicalDataTemplate.ItemContainerStyle>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="125"/>
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <CheckBox IsChecked="{Binding Path=Code.Enabled}" Margin="0,2,4,2" IsTabStop="False"
+                                                              Visibility="{Binding Path=IsRoot, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
+                                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </Grid>
+                                            </HierarchicalDataTemplate>
+                                        </TreeView.ItemTemplate>
+                                    </TreeView>
+
+                                    <!-- Fix for border inconsistency above the download button in the tree view -->
+                                    <Border BorderBrush="{DynamicResource HMM.Window.BorderBrush}" BorderThickness="1" CornerRadius="8,0,0,0"/>
+
+                                    <GridSplitter Grid.Column="1"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Stretch"
+                                                  Background="{DynamicResource HMM.Window.BorderBrush}" 
+                                                  ShowsPreview="True"
+                                                  Width="1"
+                                                  MouseDoubleClick="CodesTreeDescription_GridSplitter_MouseDoubleClick"/>
+
+                                    <Grid Grid.Column="2" Background="{DynamicResource HMM.Window.BackgroundBrush}" MouseDown="CodesViewDescription_MouseDown">
+                                        <Border BorderBrush="{DynamicResource HMM.Window.BorderBrush}" BorderThickness="1" CornerRadius="0,8,0,0">
+                                            <TextBlock Name="CodesTreeDescription"
+                                                       Margin="8,2.5,5,5"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       TextWrapping="WrapWithOverflow"
+                                                       Text="{DynamicResource CodesUIInfoHint}"
+                                                       FontStyle="Italic"
+                                                       Foreground="#FF646464"/>
+                                        </Border>
+                                    </Grid>
+                                </Grid>
+
+                                <Grid Name="CodesListContainer" Margin="10,5,10,41" Visibility="Collapsed">
                                     <Grid.RowDefinitions>
                                         <RowDefinition/>
                                         <RowDefinition Height="Auto"/>
-                                        <RowDefinition Name="CodeDescriptionRow" Height="24" MinHeight="24"/>
+                                        <RowDefinition Name="CodesListDescriptionRow" Height="24" MinHeight="24"/>
                                     </Grid.RowDefinitions>
                                     
                                     <ListView x:Name="CodesList" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Foreground="White" SelectedItem="{Binding SelectedCode}" SizeChanged="CodesList_SizeChanged"
@@ -195,9 +292,9 @@
                                                     </Setter.Value>
                                                 </Setter>
                                                 <EventSetter Event="MouseDoubleClick" Handler="CodesList_MouseDoubleClick"/>
-                                                <EventSetter Event="MouseEnter"       Handler="CodesList_MouseEnter"/>
-                                                <EventSetter Event="MouseLeave"       Handler="CodesList_MouseLeave"/>
-                                                <EventSetter Event="Selected"         Handler="CodesList_ListViewItem_Selected"/>
+                                                <EventSetter Event="MouseEnter"       Handler="CodesView_MouseEnter"/>
+                                                <EventSetter Event="MouseLeave"       Handler="CodesView_MouseLeave"/>
+                                                <EventSetter Event="Selected"         Handler="CodesView_ViewItem_Selected"/>
                                             </Style>
                                         </ListView.ItemContainerStyle>
                                         <ListView.View>
@@ -229,11 +326,11 @@
                                                   Background="{DynamicResource HMM.Window.BorderBrush}" 
                                                   ShowsPreview="True"
                                                   Height="1"
-                                                  MouseDoubleClick="CodeDescription_GridSplitter_MouseDoubleClick"/>
+                                                  MouseDoubleClick="CodesListDescription_GridSplitter_MouseDoubleClick"/>
                                     
-                                    <Grid Grid.Row="2" Background="{DynamicResource HMM.Window.BackgroundBrush}" MouseDown="CodeDescription_MouseDown">
+                                    <Grid Grid.Row="2" Background="{DynamicResource HMM.Window.BackgroundBrush}" MouseDown="CodesViewDescription_MouseDown">
                                         <Border BorderBrush="{DynamicResource HMM.Window.BorderBrush}" BorderThickness="1,0,1,1">
-                                            <TextBlock Name="CodeDescription"
+                                            <TextBlock Name="CodesListDescription"
                                                        Margin="8,2.5,5,5"
                                                        VerticalAlignment="Center"
                                                        TextTrimming="CharacterEllipsis"
@@ -243,13 +340,14 @@
                                                        Foreground="#FF646464"/>
                                         </Border>
                                     </Grid>
+
+                                    <Border x:Name="CodesFind" BorderThickness="1,1,1,1" HorizontalAlignment="Right" VerticalAlignment="Bottom" CornerRadius="8,8,0,0" Margin="0,2,20,0" Visibility="Collapsed" BorderBrush="{DynamicResource HMM.Window.BorderBrush}" Background="{DynamicResource HMM.Window.BackgroundBrush}">
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4,6,4,4">
+                                            <Label Content="{DynamicResource CodesUISearch}" Margin="0,-3,0,0"/>
+                                            <TextBox x:Name="TextBox_CodesSearch" HorizontalAlignment="Stretch" VerticalAlignment="Top" Width="150" Margin="0,0,6,0" TextChanged="TextBox_CodeSearch_TextChanged" LostFocus="TextBox_CodeSearch_LostFocus"/>
+                                        </StackPanel>
+                                    </Border>
                                 </Grid>
-                                <Border x:Name="CodesFind" BorderThickness="1,1,1,1" HorizontalAlignment="Right" VerticalAlignment="Bottom" CornerRadius="8,8,0,0" Margin="0,2,20,41" Visibility="Collapsed" BorderBrush="{DynamicResource HMM.Window.BorderBrush}" Background="{DynamicResource HMM.Window.BackgroundBrush}">
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4,6,4,4">
-                                        <Label Content="{DynamicResource CodesUISearch}" Margin="0,-3,0,0"/>
-                                        <TextBox x:Name="TextBox_CodesSearch" HorizontalAlignment="Stretch" VerticalAlignment="Top" Width="150" Margin="0,0,6,0" TextChanged="TextBox_CodeSearch_TextChanged" LostFocus="TextBox_CodeSearch_LostFocus"/>
-                                    </StackPanel>
-                                </Border>
                             </Grid>
                         </Grid>
                     </TabItem>
@@ -303,10 +401,11 @@
                             <GroupBox Header="{DynamicResource SettingsUIHMMHeader}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="2">
                                 <Grid>
                                     <StackPanel x:Name="HMMSettingsSackPanel" Margin="10,10,0,0">
-                                        <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"   IsChecked="{Binding CPKREDIR.CheckForUpdates}"    Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"   IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}" Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}" IsChecked="{Binding CPKREDIR.CheckForModUpdates}" Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"     IsChecked="{Binding CPKREDIR.KeepOpen}"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"    IsChecked="{Binding CPKREDIR.CheckForUpdates}"    Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"    IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}" Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}"  IsChecked="{Binding CPKREDIR.CheckForModUpdates}" Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"      IsChecked="{Binding CPKREDIR.KeepOpen}"           Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICodesUseTreeView}" Checked="CheckBox_CodesUseTreeView_Checked" Unchecked="CheckBox_CodesUseTreeView_Checked" Name="CheckBox_CodesUseTreeView"/>
                                     </StackPanel>
 
                                     <Grid>
@@ -347,6 +446,7 @@
                         </Grid>
                     </TabItem>
                 </TabControl>
+                
                 <Grid Grid.Row="1" Background="{DynamicResource HMM.Window.DialogBottom}">
                     <Grid Margin="8,1,8,0" VerticalAlignment="Center" Height="56">
                         <ComboBox x:Name="ComboBox_GameStatus" ItemsSource="{Binding Games}" Width="280" HorizontalAlignment="Left" Margin="0,8,5,8" SelectionChanged="Game_Changed">

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -1983,12 +1983,7 @@ namespace HedgeModManager
 
         private void UpdateCodeDescription(Code code)
         {
-            var theme = new ResourceDictionary()
-            {
-                Source = new Uri($"Themes/{RegistryConfig.UITheme}.xaml", UriKind.Relative)
-            };
-
-            var fgBrush = (SolidColorBrush)theme["HMM.Window.ForegroundBrush"];
+            var fgBrush = (SolidColorBrush)HedgeApp.Current.FindResource("HMM.Window.ForegroundBrush");
             var noBrush = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF646464");
 
             TextBlock textBlock;

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -154,8 +154,7 @@ namespace HedgeModManager
         private void SortCodesList(int index = -1)
         {
             // Set toggle checkbox and switch to user view.
-            CheckBox_CodesUseTreeView.IsChecked = RegistryConfig.CodesUseTreeView;
-            InvokeChangeCodesView(RegistryConfig.CodesUseTreeView);
+            InvokeChangeCodesView((CheckBox_CodesUseTreeView.IsChecked = RegistryConfig.CodesUseTreeView).Value);
 
             if (IsCodesTreeView)
             {
@@ -297,8 +296,16 @@ namespace HedgeModManager
 
         public void InvokeChangeCodesView(bool useTreeView = true)
         {
+            /* Using an argument to switch view, rather than the registry
+               config value, so we don't change any settings when switching
+               views temporarily. */
             if (!useTreeView)
-                goto InitListView;
+            {
+                IsCodesTreeView = false;
+                CodesListContainer.Visibility = Visibility.Visible;
+                CodesTreeContainer.Visibility = Visibility.Collapsed;
+                return;
+            }
 
             if (RegistryConfig.CodesUseTreeView)
             {
@@ -307,11 +314,6 @@ namespace HedgeModManager
                 CodesTreeContainer.Visibility = Visibility.Visible;
                 return;
             }
-
-        InitListView:
-            IsCodesTreeView = false;
-            CodesListContainer.Visibility = Visibility.Visible;
-            CodesTreeContainer.Visibility = Visibility.Collapsed;
         }
 
         public void RefreshUI()
@@ -1887,6 +1889,7 @@ namespace HedgeModManager
 
         private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            InvokeChangeCodesView(RegistryConfig.CodesUseTreeView);
             if (RefreshButton != null)
             {
                 RefreshButton.IsEnabled = MainTabControl.SelectedItem != SettingsTab;

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -153,6 +153,10 @@ namespace HedgeModManager
 
         private void SortCodesList(int index = -1)
         {
+            // Set toggle checkbox and switch to user view.
+            CheckBox_CodesUseTreeView.IsChecked = RegistryConfig.CodesUseTreeView;
+            InvokeChangeCodesView(RegistryConfig.CodesUseTreeView);
+
             if (IsCodesTreeView)
             {
                 ExpandedCodeCategories.Clear();
@@ -259,10 +263,6 @@ namespace HedgeModManager
                 if (code != null)
                     code.Enabled = true;
             });
-
-            // I am also lazy
-            CheckBox_CodesUseTreeView.IsChecked = RegistryConfig.CodesUseTreeView;
-            InvokeChangeCodesView(RegistryConfig.CodesUseTreeView);
 
             SortCodesList();
 
@@ -1692,7 +1692,6 @@ namespace HedgeModManager
                     }
                     else if (MainTabControl.SelectedItem == CodesTab)
                     {
-
                         if (CodesFind.Visibility == Visibility.Visible)
                         {
                             // Switch to user view.

--- a/HedgeModManager/UI/Models/CodeHierarchyViewModel.cs
+++ b/HedgeModManager/UI/Models/CodeHierarchyViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace HedgeModManager.UI.Models
+{
+    public class CodeHierarchyViewModel
+    {
+        public string Name { get; set; }
+
+        public Code Code { get; set; }
+
+        public bool IsExpanded { get; set; }
+
+        public bool IsRoot { get; set; } = false;
+
+        public IEnumerable<CodeHierarchyViewModel> Children { get; set; }
+    }
+}


### PR DESCRIPTION
This PR adds a new view for the codes list that sorts the codes in a tree view by category.

By default, all tree nodes are collapsed, below is an example image with all of them expanded. If this should change to always expanded by default, please do say.

![image](https://user-images.githubusercontent.com/34012267/206875091-aa3ef1b9-7bbe-465c-a51d-49a28d41b693.png)

This view is optional and can be toggled via Settings under `Use tree view for codes list`, disabling this will revert back to the tried-and-true list view instead.

Invoking the search box with `CTRL+F` will also jump back to the list view, as that makes more sense for searching, rather than jumping through tree nodes. The search bar also no longer overlaps the new description box in the list view with this PR.

![Cu30gZovKo](https://user-images.githubusercontent.com/34012267/206874673-e9b6cf5c-c731-4d1d-935c-e483fc69627e.gif)

A context menu is also available for the tree view to expand or collapse all nodes.

![image](https://user-images.githubusercontent.com/34012267/206874535-7d0f66ce-502b-4181-8887-60eb767165a1.png)

Uncategorised codes will be marked as such and will appear at the top of the list - if this should be sorted with the rest, please do say.

![image](https://user-images.githubusercontent.com/34012267/206874566-e7e1c2c1-e166-47ff-8b5a-69ad63e8bea5.png)

Future goals;
- Allow for nested categories for deeper organisation past top-level categories.