### PR TITLE
[CLI] Implement --config command

### DIFF
--- a/HedgeModManager/CLI/Commands/CliCommandConfig.cs
+++ b/HedgeModManager/CLI/Commands/CliCommandConfig.cs
@@ -1,5 +1,4 @@
 ﻿using HedgeModManager.UI;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
@@ -22,12 +21,11 @@ namespace HedgeModManager.CLI.Commands
 
                 if (modInfo.HasSchema)
                 {
-                    var config = new ModConfigWindow(modInfo);
+                    new ModConfigWindow(modInfo)
                     {
-                        config.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                        WindowStartupLocation = WindowStartupLocation.CenterScreen
                     }
-
-                    config.ShowDialog();
+                    .ShowDialog();
                 }
             }
 

--- a/HedgeModManager/CLI/Commands/CliCommandConfig.cs
+++ b/HedgeModManager/CLI/Commands/CliCommandConfig.cs
@@ -1,0 +1,28 @@
+﻿using HedgeModManager.UI;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+
+namespace HedgeModManager.CLI.Commands
+{
+    [CliCommand("config", "c", new[] { typeof(string) }, "Open config window for a mod", "--config \"{ModPath}\"", "--config \"C:\\Example Mod\\\"")]
+    public class CliCommandConfig : ICliCommand
+    {
+        public void Execute(List<CommandLine.Command> commands, CommandLine.Command command)
+        {
+            string modPath = (string)command.Inputs[0];
+
+            if (Directory.Exists(modPath))
+            {
+                var config = new ModConfigWindow(new ModInfo(modPath));
+                {
+                    config.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                }
+
+                config.ShowDialog();
+
+                HedgeApp.Current.Shutdown(0);
+            }
+        }
+    }
+}

--- a/HedgeModManager/CLI/Commands/CliCommandConfig.cs
+++ b/HedgeModManager/CLI/Commands/CliCommandConfig.cs
@@ -13,6 +13,9 @@ namespace HedgeModManager.CLI.Commands
         {
             string modPath = (string)command.Inputs[0];
 
+            if (File.Exists(modPath) && Path.GetExtension(modPath) == ".ini")
+                modPath = Path.GetDirectoryName(modPath);
+
             if (Directory.Exists(modPath))
             {
                 var modInfo = new ModInfo(modPath);
@@ -26,9 +29,9 @@ namespace HedgeModManager.CLI.Commands
 
                     config.ShowDialog();
                 }
-
-                HedgeApp.Current.Shutdown(0);
             }
+
+            HedgeApp.Current.Shutdown(0);
         }
     }
 }

--- a/HedgeModManager/CLI/Commands/CliCommandConfig.cs
+++ b/HedgeModManager/CLI/Commands/CliCommandConfig.cs
@@ -6,7 +6,7 @@ using System.Windows;
 
 namespace HedgeModManager.CLI.Commands
 {
-    [CliCommand("config", "c", new[] { typeof(string) }, "Open config window for a mod", "--config \"{ModPath}\"", "--config \"C:\\Example Mod\\\"")]
+    [CliCommand("config", "c", new[] { typeof(string) }, "Open config window for a mod", "--config {ModPath}", "--config \"C:\\Example Mod\\\"")]
     public class CliCommandConfig : ICliCommand
     {
         public void Execute(List<CommandLine.Command> commands, CommandLine.Command command)

--- a/HedgeModManager/CLI/Commands/CliCommandConfig.cs
+++ b/HedgeModManager/CLI/Commands/CliCommandConfig.cs
@@ -1,4 +1,5 @@
 ﻿using HedgeModManager.UI;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
@@ -14,12 +15,17 @@ namespace HedgeModManager.CLI.Commands
 
             if (Directory.Exists(modPath))
             {
-                var config = new ModConfigWindow(new ModInfo(modPath));
-                {
-                    config.WindowStartupLocation = WindowStartupLocation.CenterScreen;
-                }
+                var modInfo = new ModInfo(modPath);
 
-                config.ShowDialog();
+                if (modInfo.HasSchema)
+                {
+                    var config = new ModConfigWindow(modInfo);
+                    {
+                        config.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    }
+
+                    config.ShowDialog();
+                }
 
                 HedgeApp.Current.Shutdown(0);
             }

--- a/HedgeModManager/Config/RegistryConfig.cs
+++ b/HedgeModManager/Config/RegistryConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using System.Reflection;
 
 namespace HedgeModManager
 {
@@ -24,6 +25,7 @@ namespace HedgeModManager
         public static void Save()
         {
             var key = Registry.CurrentUser.CreateSubKey(ConfigPath);
+            key.SetValue("ExecutablePath", Assembly.GetExecutingAssembly().Location);
             key.SetValue("LastGame", LastGameDirectory);
             key.SetValue(nameof(ExtraGameDirectories), ExtraGameDirectories);
             key.SetValue(nameof(UILanguage), UILanguage);

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -298,20 +298,6 @@ namespace HedgeModManager
                 $"https://raw.githubusercontent.com/{RepoOwner}/{RepoName}/{RepoBranch}/HMMNetworkConfig.json"));
         }
 
-        public static void ShowHelp()
-        {
-            Console.WriteLine();
-            Console.WriteLine($"HedgeModManager {VersionString}\n");
-
-            Console.WriteLine("Commands:");
-
-            Console.WriteLine("    -encrypt");
-            Console.WriteLine("        Usage: filename [output]");
-
-            Console.WriteLine("    -decrypt");
-            Console.WriteLine("        Usage: filename [output]");
-        }
-
         public static Uri GetResourceUri(string path)
         {
             return new Uri(@"pack://application:,,,/" + Assembly.GetExecutingAssembly().GetName().Name + ";component/" + path, UriKind.Absolute);
@@ -538,6 +524,7 @@ namespace HedgeModManager
             builder.AppendLine();
             new ExceptionWindow(new Exception(builder.ToString())).ShowDialog();
         }
+
         public static void SetupThemes()
         {
             var resource = Current.TryFindResource("Themes");


### PR DESCRIPTION
This PR adds a new `--config` command to the CLI arguments, as well as a new `ExecutablePath` value for the registry config to allow DLL mods to use this new command when prompting users to configure their mod.

This command will open the mod configuration window for the specified mod.

Examples;
`HedgeModManager.exe --config ".\mods\Example Mod"`
`HedgeModManager.exe --config ".\mods\Example Mod\mod.ini"`