### PR TITLE
[UI] Added option to update codes on launch

### DIFF
--- a/HedgeModManager/Config/CPKREDIRConfig.cs
+++ b/HedgeModManager/Config/CPKREDIRConfig.cs
@@ -53,6 +53,9 @@ namespace HedgeModManager
         [IniField("HedgeModManager", "CheckModUpdates")]
         public bool CheckForModUpdates { get; set; } = true;
 
+        [IniField("HedgeModManager", "UpdateCodesOnLaunch")]
+        public bool UpdateCodesOnLaunch { get; set; } = true;
+
         [IniField("HedgeModManager", "KeepModLoaderOpen")]
         public bool KeepOpen { get; set; } = true;
 

--- a/HedgeModManager/Languages/en-AU.xaml
+++ b/HedgeModManager/Languages/en-AU.xaml
@@ -99,17 +99,18 @@
     <system:String x:Key="SettingsUILabelProfile"   >Profile:</system:String>
     <system:String x:Key="SettingsUILabelMDir"      >Mods Directory:</system:String>
     <!--   Hedge Mod Manager -->
-    <system:String x:Key="SettingsUIHMMHeader"       >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"   >Automatically check for Hedge Mod Manager updates</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"   >Automatically check for mod loader updates</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates" >Automatically check for mod updates</system:String>
-    <system:String x:Key="SettingsUIKeepHMMOpen"     >Keep Hedge Mod Manager open after starting a game</system:String>
-    <system:String x:Key="SettingsUICodesUseTreeView">Use tree view for codes list</system:String>
-    <system:String x:Key="SettingsUICheckHMMUpdate"  >Check for Updates</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"        >About Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUILanguage"        >Language:</system:String>
-    <system:String x:Key="SettingsUITheme"           >Theme:</system:String>
-    <system:String x:Key="SettingsUIReleaseChannel"  >Update Channel:</system:String>
+    <system:String x:Key="SettingsUIHMMHeader"          >Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"      >Automatically check for Hedge Mod Manager updates</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"      >Automatically check for mod loader updates</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates"    >Automatically check for mod updates</system:String>
+    <system:String x:Key="SettingsUIUpdateCodesOnLaunch">Automatically update community codes on launch</system:String>
+    <system:String x:Key="SettingsUIKeepHMMOpen"        >Keep Hedge Mod Manager open after starting a game</system:String>
+    <system:String x:Key="SettingsUICodesUseTreeView"   >Use tree view for codes list</system:String>
+    <system:String x:Key="SettingsUICheckHMMUpdate"     >Check for Updates</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"           >About Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUILanguage"           >Language:</system:String>
+    <system:String x:Key="SettingsUITheme"              >Theme:</system:String>
+    <system:String x:Key="SettingsUIReleaseChannel"     >Update Channel:</system:String>
     <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
     <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
     <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>

--- a/HedgeModManager/Languages/en-US.xaml
+++ b/HedgeModManager/Languages/en-US.xaml
@@ -99,17 +99,18 @@
     <system:String x:Key="SettingsUILabelProfile"   >Profile:</system:String>
     <system:String x:Key="SettingsUILabelMDir"      >Mods Directory:</system:String>
     <!--   Hedge Mod Manager -->
-    <system:String x:Key="SettingsUIHMMHeader"       >Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUICheckMLUpdate"   >Automatically check for Hedge Mod Manager updates</system:String>
-    <system:String x:Key="SettingsUICheckCLUpdate"   >Automatically check for mod loader updates</system:String>
-    <system:String x:Key="SettingsUICheckModUpdates" >Automatically check for mod updates</system:String>
-    <system:String x:Key="SettingsUIKeepHMMOpen"     >Keep Hedge Mod Manager open after starting a game</system:String>
-    <system:String x:Key="SettingsUICodesUseTreeView">Use tree view for codes list</system:String>
-    <system:String x:Key="SettingsUICheckHMMUpdate"  >Check for Updates</system:String>
-    <system:String x:Key="SettingsUIAboutHMM"        >About Hedge Mod Manager</system:String>
-    <system:String x:Key="SettingsUILanguage"        >Language:</system:String>
-    <system:String x:Key="SettingsUITheme"           >Theme:</system:String>
-    <system:String x:Key="SettingsUIReleaseChannel"  >Update Channel:</system:String>
+    <system:String x:Key="SettingsUIHMMHeader"          >Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUICheckMLUpdate"      >Automatically check for Hedge Mod Manager updates</system:String>
+    <system:String x:Key="SettingsUICheckCLUpdate"      >Automatically check for mod loader updates</system:String>
+    <system:String x:Key="SettingsUICheckModUpdates"    >Automatically check for mod updates</system:String>
+    <system:String x:Key="SettingsUIUpdateCodesOnLaunch">Automatically update community codes on launch</system:String>
+    <system:String x:Key="SettingsUIKeepHMMOpen"        >Keep Hedge Mod Manager open after starting a game</system:String>
+    <system:String x:Key="SettingsUICodesUseTreeView"   >Use tree view for codes list</system:String>
+    <system:String x:Key="SettingsUICheckHMMUpdate"     >Check for Updates</system:String>
+    <system:String x:Key="SettingsUIAboutHMM"           >About Hedge Mod Manager</system:String>
+    <system:String x:Key="SettingsUILanguage"           >Language:</system:String>
+    <system:String x:Key="SettingsUITheme"              >Theme:</system:String>
+    <system:String x:Key="SettingsUIReleaseChannel"     >Update Channel:</system:String>
     <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
     <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
     <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>

--- a/HedgeModManager/UI/MainWindow.xaml
+++ b/HedgeModManager/UI/MainWindow.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         Title="Hedge Mod Manager (7.0)" Unloaded="MainWindow_OnUnloaded"
         Loaded="Window_Loaded" PreviewKeyDown="Window_PreviewKeyDown"
-        MinHeight="640" MinWidth="580" Height="640" Width="580" WindowStartupLocation="CenterScreen" Style="{StaticResource HedgeWindow}">
+        MinHeight="662" MinWidth="585" Height="662" Width="585" WindowStartupLocation="CenterScreen" Style="{StaticResource HedgeWindow}">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
@@ -409,11 +409,12 @@
                             <GroupBox Header="{DynamicResource SettingsUIHMMHeader}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="2">
                                 <Grid>
                                     <StackPanel x:Name="HMMSettingsSackPanel" Margin="10,10,0,0">
-                                        <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"    IsChecked="{Binding CPKREDIR.CheckForUpdates}"    Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"    IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}" Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}"  IsChecked="{Binding CPKREDIR.CheckForModUpdates}" Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"      IsChecked="{Binding CPKREDIR.KeepOpen}"           Margin="0,0,0,5"/>
-                                        <CheckBox Content="{DynamicResource SettingsUICodesUseTreeView}" Checked="CheckBox_CodesUseTreeView_Checked" Unchecked="CheckBox_CodesUseTreeView_Checked" Name="CheckBox_CodesUseTreeView"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckMLUpdate}"       IsChecked="{Binding CPKREDIR.CheckForUpdates}"     Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckCLUpdate}"       IsChecked="{Binding CPKREDIR.CheckLoaderUpdates}"  Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICheckModUpdates}"     IsChecked="{Binding CPKREDIR.CheckForModUpdates}"  Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIUpdateCodesOnLaunch}" IsChecked="{Binding CPKREDIR.UpdateCodesOnLaunch}" Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUIKeepHMMOpen}"         IsChecked="{Binding CPKREDIR.KeepOpen}"            Margin="0,0,0,5"/>
+                                        <CheckBox Content="{DynamicResource SettingsUICodesUseTreeView}"    Checked="CheckBox_CodesUseTreeView_Checked" Unchecked="CheckBox_CodesUseTreeView_Checked" Name="CheckBox_CodesUseTreeView"/>
                                     </StackPanel>
 
                                     <Grid>

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -515,19 +515,26 @@ namespace HedgeModManager
                 string localCodes = File.ReadAllText(CodeProvider.CodesTextPath);
                 string repoCodes = await Singleton.GetInstance<HttpClient>().GetStringAsync(HedgeApp.CurrentGame.CodesURL);
 
-                if (localCodes == repoCodes)
+                if (ViewModel.CPKREDIR.UpdateCodesOnLaunch && localCodes != repoCodes)
                 {
-                    CodesOutdated = false;
-
-                    // Codes are the same, so use default text.
-                    Button_DownloadCodes.SetResourceReference(ContentProperty, "CodesUIDownload");
+                    UpdateCodes();
                 }
                 else
                 {
-                    CodesOutdated = true;
+                    if (localCodes == repoCodes)
+                    {
+                        CodesOutdated = false;
 
-                    // Codes are different, report update possibility.
-                    Button_DownloadCodes.SetResourceReference(ContentProperty, "CodesUIUpdate");
+                        // Codes are the same, so use default text.
+                        Button_DownloadCodes.SetResourceReference(ContentProperty, "CodesUIDownload");
+                    }
+                    else
+                    {
+                        CodesOutdated = true;
+
+                        // Codes are different, report update possibility.
+                        Button_DownloadCodes.SetResourceReference(ContentProperty, "CodesUIUpdate");
+                    }
                 }
             }
             catch (HttpRequestException) { /* do nothing for http exceptions */ }
@@ -1414,19 +1421,13 @@ namespace HedgeModManager
                 RefreshProfiles();
                 Refresh();
                 UpdateStatus(string.Format(Localise("StatusUIGameChange"), HedgeApp.CurrentGame));
-                if (HedgeApp.CurrentGame != Games.Unknown)
-                {
-                    // Schedule checking for code updates if available.
-                    if (Button_DownloadCodes.IsEnabled)
-                        await CheckForCodeUpdates();
-                }
                 await CheckForUpdatesAsync();
             }
 
             await RunTask(CheckForLoaderUpdateAsync());
         }
 
-        private void UI_Download_Codes(object sender, RoutedEventArgs e)
+        private void UpdateCodes()
         {
             UpdateStatus(string.Format(Localise("StatusUIDownloadingCodes"), HedgeApp.CurrentGame));
             try
@@ -1491,6 +1492,11 @@ namespace HedgeModManager
             {
                 UpdateStatus(Localise("StatusUIDownloadFailed"));
             }
+        }
+
+        private void UI_Download_Codes(object sender, RoutedEventArgs e)
+        {
+            UpdateCodes();
         }
 
         private void UI_OpenMods_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This PR adds a new config option that makes community codes update on launch of Hedge Mod Manager.

Codes will be updated after mod updates have been addressed.

New string to localise: `SettingsUIUpdateCodesOnLaunch`