### PR TITLE
Implement Code Libraries

### DIFF
--- a/HedgeModManager/BasicLexer.cs
+++ b/HedgeModManager/BasicLexer.cs
@@ -48,11 +48,15 @@ namespace HedgeModManager
                     if (token.Kind == SyntaxKind.IdentifierToken)
                     {
                         var directive = new DirectiveSyntax { FullSpan = new TextSpan(start, 1), Name = token.Text };
-                        if (directive.Name == "load")
+                        if (directive.Name is "load")
                         {
                             directive.Kind = SyntaxKind.LoadDirectiveTrivia;
                         }
-                        else if (directive.Name == "r")
+                        else if (directive.Name is "r" or "ref")
+                        {
+                            directive.Kind = SyntaxKind.ReferenceDirectiveTrivia;
+                        }
+                        else if (directive.Name is "lib")
                         {
                             directive.Kind = SyntaxKind.ReferenceDirectiveTrivia;
                         }

--- a/HedgeModManager/BasicLexer.cs
+++ b/HedgeModManager/BasicLexer.cs
@@ -52,10 +52,6 @@ namespace HedgeModManager
                         {
                             directive.Kind = SyntaxKind.LoadDirectiveTrivia;
                         }
-                        else if (directive.Name is "r" or "ref")
-                        {
-                            directive.Kind = SyntaxKind.ReferenceDirectiveTrivia;
-                        }
                         else if (directive.Name is "lib")
                         {
                             directive.Kind = SyntaxKind.ReferenceDirectiveTrivia;

--- a/HedgeModManager/BasicLexer.cs
+++ b/HedgeModManager/BasicLexer.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace HedgeModManager
+{
+    public class BasicLexer
+    {
+        private static bool IsAlphabet(char c)
+        {
+            return c is >= 'a' and <= 'z' || c is >= 'A' and <= 'Z';
+        }
+
+        private static bool IsWhitespace(char c)
+        {
+            return c is ' ' or '\t' or '\r' or '\n';
+        }
+
+        public static List<DirectiveSyntax> ParseDirectives(string text)
+        {
+            var directives = new List<DirectiveSyntax>();
+            int offset = 0;
+            int parserState = 0;
+            int start = 0;
+
+            while (offset < text.Length)
+            {
+                var token = ParseToken(text, offset);
+                if (token.Kind == SyntaxKind.EndOfFileToken)
+                    break;
+
+                if (parserState == 0)
+                {
+                    if (token.Kind == SyntaxKind.HashToken)
+                    {
+                        start = offset;
+                        directives.Add(new DirectiveSyntax());
+                        parserState = 1;
+                    }
+                }
+                else if (parserState == 1)
+                {
+                    if (token.Kind == SyntaxKind.IdentifierToken)
+                    {
+                        var directive = new DirectiveSyntax { FullSpan = new TextSpan(start, 1), Name = token.Text };
+                        if (directive.Name == "load")
+                        {
+                            directive.Kind = SyntaxKind.LoadDirectiveTrivia;
+                        }
+                        else if (directive.Name == "r")
+                        {
+                            directive.Kind = SyntaxKind.ReferenceDirectiveTrivia;
+                        }
+
+                        directives[directives.Count - 1] = directive;
+                        parserState = 2;
+                    }
+                    else if (token.Kind == SyntaxKind.WhitespaceTrivia && token.HasNewLine)
+                    {
+                        directives.RemoveAt(directives.Count - 1);
+                        parserState = 0;
+                    }
+                }
+                else if (parserState == 2)
+                {
+                    if (token.Kind != SyntaxKind.WhitespaceTrivia)
+                    {
+                        var directive = directives[directives.Count - 1];
+                        directive.FullSpan = new TextSpan(directive.FullSpan.Start, (offset + token.Span.Length) - directive.FullSpan.Start);
+                        directive.Value = string.IsNullOrEmpty(token.ValueText) ? token.Text : token.ValueText;
+                        directives[directives.Count - 1] = directive;
+
+                        parserState = 0;
+                    }
+                    else if (token.Kind == SyntaxKind.WhitespaceTrivia && token.HasNewLine)
+                    {
+                        parserState = 0;
+                    }
+                }
+
+                offset += token.Span.Length;
+            }
+
+            if (parserState != 0)
+            {
+                directives.RemoveAt(directives.Count - 1);
+            }
+
+            return directives;
+        }
+
+        public static Token ParseToken(string text, int offset = 0)
+        {
+            if (offset >= text.Length)
+                return Token.Create(text, SyntaxKind.EndOfFileToken, 0, 0);
+
+            char c = text[offset];
+
+            if (IsWhitespace(c))
+            {
+                int l = 0;
+                while (offset + l < text.Length && IsWhitespace(text[offset + l]))
+                    l++;
+
+                return Token.Create(text, SyntaxKind.WhitespaceTrivia, 0, l);
+            }
+
+            if (IsAlphabet(c))
+            {
+                int l = 0;
+                while (offset + l < text.Length && IsAlphabet(text[offset + l]))
+                    l++;
+
+                return Token.Create(text, SyntaxKind.IdentifierToken, offset, l);
+            }
+            else if (c == '"')
+            {
+                int l = 1;
+                while (offset + l < text.Length && (text[offset + l] != '"' && text[offset + l - 1] != '\\'))
+                    l++;
+
+                return Token.Create(text, SyntaxKind.StringLiteralToken, offset, l + 1, 1, l - 1);
+            }
+
+            switch (c)
+            {
+                case '#':
+                    return Token.Create(text, SyntaxKind.HashToken, 0, 1);
+
+                default:
+                    break;
+            }
+
+            return Token.Create(text, SyntaxKind.None, 0, 1);
+        }
+
+        public struct DirectiveSyntax
+        {
+            public string Name = string.Empty;
+            public string Value = string.Empty;
+            public SyntaxKind Kind;
+            public TextSpan FullSpan;
+
+            public DirectiveSyntax()
+            {
+            }
+        }
+
+        public struct Token
+        {
+            public string Text;
+            public TextSpan Span;
+            public TextSpan ValueSpan;
+            public SyntaxKind Kind;
+
+            public string ValueText => ValueSpan.Length > 0 ? Text.Substring(ValueSpan.Start, ValueSpan.Length) : string.Empty;
+
+            public bool HasNewLine => Text.Contains('\n') || Text.Contains('\r');
+
+            public static Token Create(string text, SyntaxKind kind, int o, int l)
+            {
+                return new Token()
+                {
+                    Text = o + l <= text.Length ? text.Substring(o, l) : string.Empty,
+                    Span = new TextSpan(o, l),
+                    Kind = kind
+                };
+            }
+
+            public static Token Create(string text, SyntaxKind kind, int o, int l, int vo, int vl)
+            {
+                return new Token()
+                {
+                    Text = o + l <= text.Length ? text.Substring(o, l) : string.Empty,
+                    Span = new TextSpan(o, l),
+                    ValueSpan = new TextSpan(vo, vl),
+                    Kind = kind,
+                };
+            }
+        }
+    }
+}

--- a/HedgeModManager/CodeFile.cs
+++ b/HedgeModManager/CodeFile.cs
@@ -23,6 +23,7 @@ namespace HedgeModManager
 
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
         public List<Code> Codes { get; set; } = new List<Code>();
+        public IEnumerable<Code> ExecutableCodes => Codes.Where(x => x.IsExecutable());
 
         public CodeFile() { }
 
@@ -52,7 +53,7 @@ namespace HedgeModManager
 
         public List<CodeDiffResult> Diff(CodeFile old)
         {
-            var diff       = new List<CodeDiffResult>();
+            var diff = new List<CodeDiffResult>();
             var addedCodes = new List<string>();
 
             foreach (var code in Codes)
@@ -199,25 +200,25 @@ namespace HedgeModManager
         public CodeDiffResult(string changelog, CodeDiffType type)
         {
             Changelog = changelog;
-            Type      = type;
+            Type = type;
         }
 
         public CodeDiffResult(string changelog, CodeDiffType type, string originalName, string newName)
         {
-            Changelog    = changelog;
-            Type         = type;
+            Changelog = changelog;
+            Type = type;
             OriginalName = originalName;
-            NewName      = newName;
+            NewName = newName;
         }
 
         public override string ToString()
         {
             string key = Type switch
             {
-                CodeDiffType.Added   => "DiffUIAdded",
+                CodeDiffType.Added => "DiffUIAdded",
                 CodeDiffType.Removed => "DiffUIRemoved",
                 CodeDiffType.Renamed => "DiffUIRenamed",
-                _                    => "DiffUIModified",
+                _ => "DiffUIModified",
             };
 
             return Lang.LocaliseFormat(key, Changelog);
@@ -232,6 +233,11 @@ namespace HedgeModManager
         }
     }
 
+    public enum CodeType
+    {
+        Code, Patch, Library, Unknown
+    }
+
     public class Code : INotifyPropertyChanged
     {
         public string Name { get; set; }
@@ -242,7 +248,7 @@ namespace HedgeModManager
 
         public string Description { get; set; }
 
-        public bool IsPatch { get; set; }
+        public CodeType Type { get; set; }
 
         public bool Enabled { get; set; }
 
@@ -305,60 +311,64 @@ namespace HedgeModManager
                     if (line == null)
                         continue;
 
-                    bool isCode = line.StartsWith("Code");
-                    bool isPatch = line.StartsWith("Patch");
-                    if (isPatch || isCode)
+                    var firstSpace = line.IndexOf(' ');
+                    if (firstSpace > 0)
                     {
-                        currentCode = new Code();
-                        codes.Add(currentCode);
+                        var type = line.Substring(0, firstSpace);
 
-                        currentCode.Header.AppendLine(line);
-
-                        var matches = Regex.Matches(line, "(\"[^\"]*\"|[^\"]+)(\\s+|$)");
-                        currentCode.IsPatch = isPatch;
-                        var name = matches[1].Value.Trim(' ', '"');
-
-                        currentCode.Name = name;
-
-                        for (int i = 2; i < matches.Count; i++)
+                        if (CodeTypeFromString(type, out var codeType))
                         {
-                            var match = matches[i].Value;
+                            currentCode = new Code();
+                            currentCode.Type = codeType;
+                            codes.Add(currentCode);
 
-                            if (match.Trim().Equals("in", StringComparison.OrdinalIgnoreCase))
+                            currentCode.Header.AppendLine(line);
+
+                            var matches = Regex.Matches(line, "(\"[^\"]*\"|[^\"]+)(\\s+|$)");
+                            var name = matches[1].Value.Trim(' ', '"');
+
+                            currentCode.Name = name;
+
+                            for (int i = 2; i < matches.Count; i++)
                             {
-                                i++;
-                                currentCode.Category = matches[i].Value.Trim(' ', '"');
+                                var match = matches[i].Value;
+
+                                if (match.Trim().Equals("in", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    i++;
+                                    currentCode.Category = matches[i].Value.Trim(' ', '"');
+                                }
+
+                                if (match.Trim().Equals("by", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    i++;
+                                    currentCode.Author = matches[i].Value.Trim(' ', '"');
+                                }
+
+                                if (match.Trim().Equals("does", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    i++;
+
+                                    /* If the line ends with "does" on its own,
+                                       the description will be on the next line. */
+                                    if (line.EndsWith("does"))
+                                        isMultilineDescription = true;
+                                    else
+                                        currentCode.Description = matches[i].Value.Trim(' ', '"');
+                                }
                             }
 
-                            if (match.Trim().Equals("by", StringComparison.OrdinalIgnoreCase))
-                            {
-                                i++;
-                                currentCode.Author = matches[i].Value.Trim(' ', '"');
-                            }
-
-                            if (match.Trim().Equals("does", StringComparison.OrdinalIgnoreCase))
-                            {
-                                i++;
-
-                                /* If the line ends with "does" on its own,
-                                   the description will be on the next line. */
-                                if (line.EndsWith("does"))
-                                    isMultilineDescription = true;
-                                else
-                                    currentCode.Description = matches[i].Value.Trim(' ', '"');
-                            }
+                            continue;
                         }
-
-                        continue;
                     }
 
                     if (isMultilineDescription)
                     {
                         string startDelimiter = "/*";
-                        string endDelimiter   = "*/";
+                        string endDelimiter = "*/";
 
                         bool lineContainsStartDelimiter = false;
-                        bool lineContainsEndDelimiter   = false;
+                        bool lineContainsEndDelimiter = false;
 
                         currentCode.Header.AppendLine(line);
 
@@ -369,7 +379,7 @@ namespace HedgeModManager
 
                             lineContainsStartDelimiter = true;
                         }
-                        
+
                         if (line.EndsWith(endDelimiter))
                         {
                             isMultilineDescription = false;
@@ -415,6 +425,22 @@ namespace HedgeModManager
             return codes;
         }
 
+        public List<string> GetReferences()
+        {
+            var references = new List<string>();
+
+            var tree = ParseSyntaxTree();
+
+            var unit = tree.GetCompilationUnitRoot();
+
+            foreach (var reference in unit.GetReferenceDirectives())
+            {
+                references.Add(reference.File.ValueText);
+            }
+
+            return references;
+        }
+
         public SyntaxTree ParseSyntaxTree()
         {
             var hash = Lines.ToString().GetHashCode();
@@ -436,41 +462,71 @@ namespace HedgeModManager
             var unit = tree.GetCompilationUnitRoot();
             unit = (CompilationUnitSyntax)new OptionalColonRewriter().Visit(unit);
 
-            var allowedMembers = new List<StatementSyntax>();
-            var disallowedMembers = new List<MemberDeclarationSyntax>();
+            var classUnit = SyntaxFactory
+                .ClassDeclaration(MakeInternalName())
+                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)));
 
-            foreach (MemberDeclarationSyntax member in unit.Members)
+            if (IsExecutable())
             {
-                if (member is GlobalStatementSyntax globalStatement)
+                var localMembers = new List<StatementSyntax>();
+                var globalMembers = new List<MemberDeclarationSyntax>();
+
+                foreach (var member in unit.Members)
                 {
-                    allowedMembers.Add(globalStatement.Statement);
-                }
-                else if (member is FieldDeclarationSyntax fieldDeclaration)
-                {
-                    if (!member.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    if (member is GlobalStatementSyntax globalStatement)
                     {
-                        allowedMembers.Add(SyntaxFactory.LocalDeclarationStatement(member.Modifiers, fieldDeclaration.Declaration));
+                        localMembers.Add(globalStatement.Statement);
+                    }
+                    else if (member is FieldDeclarationSyntax fieldDeclaration)
+                    {
+                        if (!member.Modifiers.Any(SyntaxKind.StaticKeyword))
+                        {
+                            localMembers.Add(SyntaxFactory.LocalDeclarationStatement(member.Modifiers, fieldDeclaration.Declaration));
+                        }
+                        else
+                        {
+                            globalMembers.Add(member);
+                        }
                     }
                     else
                     {
-                        disallowedMembers.Add(member);
+                        globalMembers.Add(member);
                     }
                 }
-                else
-                {
-                    disallowedMembers.Add(member);
-                }
+
+                var funcUnit = SyntaxFactoryEx.MethodDeclaration(Type == CodeType.Patch ? "Init" : "OnFrame", "void",
+                    SyntaxFactory.Block(localMembers), "public");
+
+                classUnit = classUnit
+                    .WithMembers(SyntaxFactory.List(globalMembers))
+                    .AddMembers(CodeProvider.LoaderExecutableMethod)
+                    .AddMembers(funcUnit);
             }
+            else if (Type == CodeType.Library)
+            {
+                var filteredMembers = new List<MemberDeclarationSyntax>(unit.Members.Count);
 
-            var funcUnit = SyntaxFactoryEx.MethodDeclaration(IsPatch ? "Init" : "OnFrame", "void",
-                SyntaxFactory.Block(allowedMembers), "public");
+                foreach (var member in unit.Members)
+                {
+                    if (member is MethodDeclarationSyntax method)
+                    {
+                        method = method.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+                        filteredMembers.Add(method);
+                        continue;
+                    }
 
-            var classUnit = SyntaxFactory
-                .ClassDeclaration(Regex.Replace($"{Name}_{Guid.NewGuid()}", "[^a-z_0-9]", string.Empty, RegexOptions.IgnoreCase))
-                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)))
-                .WithMembers(SyntaxFactory.List(disallowedMembers))
-                .AddMembers(funcUnit)
-                .AddMembers(CodeProvider.LoaderExecutableMethod);
+                    if (member is FieldDeclarationSyntax field)
+                    {
+                        field = field.WithModifiers(SyntaxTokenList.Create(SyntaxFactory.Token(SyntaxKind.StaticKeyword)));
+                        filteredMembers.Add(field);
+                        continue;
+                    }
+
+                    filteredMembers.Add(member);
+                }
+
+                classUnit = classUnit.WithMembers(SyntaxFactory.List(filteredMembers));
+            }
 
             return SyntaxFactory.CompilationUnit()
                 .AddMembers(classUnit)
@@ -478,11 +534,43 @@ namespace HedgeModManager
                 .AddUsings(CodeProvider.PredefinedUsingDirectives);
         }
 
+        public bool IsExecutable()
+            => Type == CodeType.Patch || Type == CodeType.Code;
+
         public SyntaxTree CreateSyntaxTree()
         {
             return SyntaxFactory.SyntaxTree(CreateCompilationUnit());
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+
+        private string MakeInternalName()
+        {
+            if (Type == CodeType.Library)
+            {
+                return Name;
+            }
+
+            return Regex.Replace($"{Name}_{Guid.NewGuid()}", "[^a-z_0-9]", string.Empty, RegexOptions.IgnoreCase);
+        }
+
+        public static bool CodeTypeFromString(string text, out CodeType type)
+        {
+            switch (text)
+            {
+                case "Code":
+                    type = CodeType.Code;
+                    return true;
+                case "Patch":
+                    type = CodeType.Patch;
+                    return true;
+                case "Library":
+                    type = CodeType.Library;
+                    return true;
+            }
+
+            type = CodeType.Unknown;
+            return false;
+        }
     }
 }

--- a/HedgeModManager/CodeFile.cs
+++ b/HedgeModManager/CodeFile.cs
@@ -521,6 +521,13 @@ namespace HedgeModManager
                         filteredMembers.Add(field);
                         continue;
                     }
+                    
+                    if (member is PropertyDeclarationSyntax property)
+                    {
+                        property = property.WithModifiers(SyntaxTokenList.Create(SyntaxFactory.Token(SyntaxKind.StaticKeyword)));
+                        filteredMembers.Add(property);
+                        continue;
+                    }
 
                     filteredMembers.Add(member);
                 }

--- a/HedgeModManager/CodeProvider.cs
+++ b/HedgeModManager/CodeProvider.cs
@@ -101,7 +101,7 @@ namespace HedgeModManager
                     var libSource = sources.FirstOrDefault(x => x.Name == lib);
                     if (libSource == null)
                     {
-                        continue;
+                        throw new Exception($"Unable to find dependency library {lib}");
                     }
 
                     trees.Add(libSource.CreateSyntaxTree());

--- a/HedgeModManager/CodeProvider.cs
+++ b/HedgeModManager/CodeProvider.cs
@@ -136,18 +136,15 @@ namespace HedgeModManager
         public static List<MetadataReference> GetLoadAssemblies<TCollection>(TCollection sources, params string[] lookupPaths) where TCollection : IEnumerable<Code>
         {
             var meta = new List<MetadataReference>();
-
-            var trees = from source in sources select source.ParseSyntaxTree();
+            
             var basePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
             var wpfPath = Path.Combine(basePath, "WPF");
 
-            foreach (var tree in trees)
+            foreach (var source in sources)
             {
-                var unit = tree.GetCompilationUnitRoot();
-                var loads = unit.GetLoadDirectives();
-                foreach (var load in loads)
+                foreach (var load in source.ParseSyntaxTree().PreprocessorDirectives.Where(x => x.Kind == SyntaxKind.LoadDirectiveTrivia))
                 {
-                    var value = load.File.ValueText;
+                    var value = load.Value;
                     var path = Path.Combine(basePath, value);
                     if (File.Exists(path))
                     {

--- a/HedgeModManager/CodeProvider.cs
+++ b/HedgeModManager/CodeProvider.cs
@@ -57,31 +57,55 @@ namespace HedgeModManager
             {
                 try
                 {
-                    CompileCodes(new Code[0], Stream.Null);
+                    CompileCodes(Array.Empty<Code>(), Stream.Null);
                 }
                 catch { }
             }).Start();
         }
 
-        public static Task CompileCodes(IEnumerable<Code> sources, string assemblyPath, params string[] loadsPaths)
+        public static Task CompileCodes<TCollection>(TCollection sources, string assemblyPath, params string[] loadsPaths) where TCollection : IEnumerable<Code>
         {
             lock (mLockContext)
             {
-                using (var stream = File.Create(assemblyPath))
-                {
-                    return CompileCodes(sources, stream, loadsPaths);
-                }
+                using var stream = File.Create(assemblyPath);
+                return CompileCodes(sources, stream, loadsPaths);
             }
         }
 
-        public static Task CompileCodes(IEnumerable<Code> sources, Stream resultStream, params string[] loadPaths)
+        public static Task CompileCodes<TCollection>(TCollection sources, Stream resultStream, params string[] loadPaths) where TCollection : IEnumerable<Code>
         {
             lock (mLockContext)
             {
                 var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
-                var trees = from source in sources select source.CreateSyntaxTree();
-
+                var trees = new List<SyntaxTree>();
+                var libs = new HashSet<string>();
                 var loads = GetLoadAssemblies(sources, loadPaths);
+                
+                foreach (var source in sources)
+                {
+                    if (!source.IsExecutable())
+                    {
+                        continue;
+                    }
+
+                    trees.Add(source.CreateSyntaxTree());
+
+                    foreach (string reference in source.GetReferences())
+                    {
+                        libs.Add(reference);
+                    }
+                }
+
+                foreach (string lib in libs)
+                {
+                    var libSource = sources.FirstOrDefault(x => x.Name == lib);
+                    if (libSource == null)
+                    {
+                        continue;
+                    }
+
+                    trees.Add(libSource.CreateSyntaxTree());
+                }
 
                 loads.Add(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
                 loads.Add(MetadataReference.CreateFromFile(typeof(Binder).Assembly.Location));
@@ -109,7 +133,7 @@ namespace HedgeModManager
             }
         }
 
-        public static List<MetadataReference> GetLoadAssemblies(IEnumerable<Code> sources, params string[] lookupPaths)
+        public static List<MetadataReference> GetLoadAssemblies<TCollection>(TCollection sources, params string[] lookupPaths) where TCollection : IEnumerable<Code>
         {
             var meta = new List<MetadataReference>();
 

--- a/HedgeModManager/ModsDB.cs
+++ b/HedgeModManager/ModsDB.cs
@@ -211,7 +211,7 @@ namespace HedgeModManager
 
                 foreach (var code in CodesDatabase.Codes)
                 {
-                    if (code.Enabled)
+                    if (code.Enabled || code.Type == CodeType.Library)
                         codes.Add(code);
                 }
 

--- a/HedgeModManager/SyntaxTreeEx.cs
+++ b/HedgeModManager/SyntaxTreeEx.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace HedgeModManager
+{
+    public class SyntaxTreeEx : CSharpSyntaxTree
+    {
+        public List<BasicLexer.DirectiveSyntax> PreprocessorDirectives { get; set; } = new();
+        private CSharpSyntaxTree mBaseSyntaxTree;
+        
+        private SyntaxTreeEx(CSharpSyntaxTree baseTree)
+        {
+            mBaseSyntaxTree = baseTree;
+        }
+
+        private static string ProcessText(string text, out List<BasicLexer.DirectiveSyntax> directives)
+        {
+            directives = BasicLexer.ParseDirectives(text);
+            var body = new StringBuilder(text);
+
+            foreach (var directive in directives)
+            {
+                if (directive.Kind == SyntaxKind.LoadDirectiveTrivia)
+                {
+                    for (int i = 0; i < directive.FullSpan.Length; i++)
+                    {
+                        body[directive.FullSpan.Start + i] = ' ';
+                    }
+                }
+            }
+
+            var tokens = SyntaxFactory.ParseTokens(body.ToString(), options: new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.Parse));
+            using var enumerator = tokens.GetEnumerator();
+            enumerator.MoveNext();
+
+            var first = enumerator.Current;
+            if (first.IsKind(SyntaxKind.OpenBraceToken))
+            {
+                var braces = new List<SyntaxToken>(32) { first };
+                while (enumerator.MoveNext())
+                {
+                    if (enumerator.Current.IsKind(SyntaxKind.OpenBraceToken) ||
+                        enumerator.Current.IsKind(SyntaxKind.CloseBraceToken))
+                    {
+                        braces.Add(enumerator.Current);
+                    }
+                }
+
+                if (braces.Count == 0 || braces.Count % 2 != 0 || !braces.Last().IsKind(SyntaxKind.CloseBraceToken))
+                {
+                    return body.ToString();
+                }
+
+                return body.ToString(braces[0].Span.End, braces.Last().SpanStart - braces[0].Span.End);
+            }
+
+            return body.ToString();
+        }
+
+        public static SyntaxTreeEx Parse(string text)
+        {
+            var tree = new SyntaxTreeEx(ParseText(ProcessText(text, out var directives), new CSharpParseOptions(kind: SourceCodeKind.Script)) as CSharpSyntaxTree);
+            tree.PreprocessorDirectives = directives;
+            return tree;
+        }
+
+        public override bool TryGetText(out SourceText text)
+        {
+            return mBaseSyntaxTree.TryGetText(out text);
+        }
+
+        public override SourceText GetText(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return mBaseSyntaxTree.GetText(cancellationToken);
+        }
+
+        public override CSharpSyntaxNode GetRoot(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return mBaseSyntaxTree.GetRoot(cancellationToken);
+        }
+
+        public override bool TryGetRoot(out CSharpSyntaxNode root)
+        {
+            return mBaseSyntaxTree.TryGetRoot(out root);
+        }
+
+        public override SyntaxReference GetReference(SyntaxNode node)
+        {
+            return mBaseSyntaxTree.GetReference(node);
+        }
+
+        public override SyntaxTree WithRootAndOptions(SyntaxNode root, ParseOptions options)
+        {
+            return mBaseSyntaxTree.WithRootAndOptions(root, options);
+        }
+
+        public override SyntaxTree WithFilePath(string path)
+        {
+            return mBaseSyntaxTree.WithFilePath(path);
+        }
+
+        public override string FilePath => mBaseSyntaxTree.FilePath;
+
+        public override bool HasCompilationUnitRoot => mBaseSyntaxTree.HasCompilationUnitRoot;
+
+        public override CSharpParseOptions Options => mBaseSyntaxTree.Options;
+
+        public override int Length => mBaseSyntaxTree.Length;
+
+        public override Encoding Encoding => mBaseSyntaxTree.Encoding;
+    }
+}

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -173,7 +173,7 @@ namespace HedgeModManager
                     }
                 }
 
-                CodesTree.ItemsSource = CodesDatabase.Codes.OrderBy(x => x.Category).ThenBy(x => x.Name).GroupBy(x => x.Category).Select
+                CodesTree.ItemsSource = CodesDatabase.ExecutableCodes.OrderBy(x => x.Category).ThenBy(x => x.Name).GroupBy(x => x.Category).Select
                 (
                     (cat) =>
                     {
@@ -233,14 +233,11 @@ namespace HedgeModManager
                         CodesList.Items.Insert(0, code);
                 }
 
-                CodesDatabase.Codes.ForEach
-                (
-                    (code) =>
-                    {
-                        if (!code.Enabled)
-                            CodesList.Items.Add(code);
-                    }
-                );
+                foreach (var code in CodesDatabase.ExecutableCodes)
+                {
+                    if (!code.Enabled)
+                        CodesList.Items.Add(code);
+                }
             }
         }
 
@@ -410,7 +407,7 @@ namespace HedgeModManager
             CodesList.Items.Clear();
 
             int enabledIndex = 0;
-            foreach (Code code in CodesDatabase.Codes)
+            foreach (var code in CodesDatabase.ExecutableCodes)
             {
                 if
                 (


### PR DESCRIPTION
A lot of times codes tend to share codes, or run into conflicts because they target the same things. Libraries help resolve this by allowing codes to share code and states.

For example, if 2 codes want they can share a mutual list using a library that could write to a game's memory. e.g
```cs
Library "ModelHelpers"
public HashSet<string> Models;
public void Insert(string name)
{
    Models.Add(name);
    // Pretend we're doing something with 'Models'
}

Patch "Foo" by "Fighters"
#lib "ModelHelpers" // Libraries are referenced using #r
ModelHelpers.Insert("sonic");

Patch "Bar" by "Coders"
#lib "ModelHelpers"
ModelHelpers.Insert("mario");
```

All methods and fields in libraries are implied static, except for classes. But classes will always be exposed as sub-classes.