### PR TITLE
Ask development channel user if they want to switch to release if a new update is available

### DIFF
--- a/HedgeModManager/Languages/en-AU.xaml
+++ b/HedgeModManager/Languages/en-AU.xaml
@@ -189,12 +189,14 @@
     <system:String x:Key="StatusUINoCodeUpdatesFound"     >No code updates found</system:String>
 
     <!-- Dialog UI Strings -->
-    <system:String xml:space="preserve" x:Key="DialogUINoGameDirAccess">Hedge Mod Manager could not access the game directory.&#x0a;Please ensure the Users group has &quot;Write&quot; set to Allow on the directory below and all of its files and folders.&#x0a;&#x0a;{0}</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIDeleteMod"      >Are you sure you want to delete &quot;{0}&quot;?&#x0a;This action cannot be undone!</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModNewest"      >{0} is already up to date.</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModUpdate"      >A newer version of {0} available! ({1})</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate">Are you sure you want to cancel updating?&#x0a;This may corrupt {0}</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUINoDecompressor" >Could not find 7-Zip or WinRAR!&#x0a;This is required to extract the mod data&#x0a;&#x0a;Please make sure you have either one installed on your system.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINoGameDirAccess"       >Hedge Mod Manager could not access the game directory.&#x0a;Please ensure the Users group has &quot;Write&quot; set to Allow on the directory below and all of its files and folders.&#x0a;&#x0a;{0}</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIDeleteMod"             >Are you sure you want to delete &quot;{0}&quot;?&#x0a;This action cannot be undone!</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModNewest"             >{0} is already up to date.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModUpdate"             >A newer version of {0} available! ({1})</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate"       >Are you sure you want to cancel updating?&#x0a;This may corrupt {0}</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINoDecompressor"        >Could not find 7-Zip or WinRAR!&#x0a;This is required to extract the mod data&#x0a;&#x0a;Please make sure you have either one installed on your system.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINewRelUpdateOnDevTitle">New Release Channel Update</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINewRelUpdateOnDev"     >There is a new update on the Release channel. Sticking with the Development channel may result in unwanted instability.&#x0a;&#x0a;Would you like to switch to the Release channel?</system:String>
 
     <!-- Status UI Lang Stuff Strings -->
     <system:String x:Key="StatusUIUpdateCompletedSingular"      >completed</system:String>

--- a/HedgeModManager/Languages/en-AU.xaml
+++ b/HedgeModManager/Languages/en-AU.xaml
@@ -111,9 +111,9 @@
     <system:String x:Key="SettingsUILanguage"           >Language:</system:String>
     <system:String x:Key="SettingsUITheme"              >Theme:</system:String>
     <system:String x:Key="SettingsUIReleaseChannel"     >Update Channel:</system:String>
-    <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
-    <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
-    <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
+    <system:String x:Key="SettingsUIChangingChannelTitle" >Switching Update Channel</system:String>
+    <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to switch to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to switch channels.</system:String>
+    <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to switch to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to switch channels.</system:String>
 
     <!-- MainWindow UI Strings -->
     <system:String x:Key="MainUIInstallFormHeader"    >Install a mod by...</system:String>

--- a/HedgeModManager/Languages/en-US.xaml
+++ b/HedgeModManager/Languages/en-US.xaml
@@ -189,12 +189,14 @@
     <system:String x:Key="StatusUINoCodeUpdatesFound"     >No code updates found</system:String>
 
     <!-- Dialog UI Strings -->
-    <system:String xml:space="preserve" x:Key="DialogUINoGameDirAccess">Hedge Mod Manager could not access the game directory.&#x0a;Please ensure the Users group has &quot;Write&quot; set to Allow on the directory below and all of its files and folders.&#x0a;&#x0a;{0}</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIDeleteMod"      >Are you sure you want to delete &quot;{0}&quot;?&#x0a;This action cannot be undone!</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModNewest"      >{0} is already up to date.</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModUpdate"      >A newer version of {0} available! ({1})</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate">Are you sure you want to cancel updating?&#x0a;This may corrupt {0}</system:String>
-    <system:String xml:space="preserve" x:Key="DialogUINoDecompressor" >Could not find 7-Zip or WinRAR!&#x0a;This is required to extract the mod data&#x0a;&#x0a;Please make sure you have either one installed on your system.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINoGameDirAccess"       >Hedge Mod Manager could not access the game directory.&#x0a;Please ensure the Users group has &quot;Write&quot; set to Allow on the directory below and all of its files and folders.&#x0a;&#x0a;{0}</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIDeleteMod"             >Are you sure you want to delete &quot;{0}&quot;?&#x0a;This action cannot be undone!</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModNewest"             >{0} is already up to date.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModUpdate"             >A newer version of {0} available! ({1})</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUIModCancelUpdate"       >Are you sure you want to cancel updating?&#x0a;This may corrupt {0}</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINoDecompressor"        >Could not find 7-Zip or WinRAR!&#x0a;This is required to extract the mod data&#x0a;&#x0a;Please make sure you have either one installed on your system.</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINewRelUpdateOnDevTitle">New Release Channel Update</system:String>
+    <system:String xml:space="preserve" x:Key="DialogUINewRelUpdateOnDev"     >There is a new update on the Release channel. Sticking with the Development channel may result in unwanted instability.&#x0a;&#x0a;Would you like to switch to the Release channel?</system:String>
 
     <!-- Status UI Lang Stuff Strings -->
     <system:String x:Key="StatusUIUpdateCompletedSingular"      >completed</system:String>

--- a/HedgeModManager/Languages/en-US.xaml
+++ b/HedgeModManager/Languages/en-US.xaml
@@ -111,9 +111,9 @@
     <system:String x:Key="SettingsUILanguage"           >Language:</system:String>
     <system:String x:Key="SettingsUITheme"              >Theme:</system:String>
     <system:String x:Key="SettingsUIReleaseChannel"     >Update Channel:</system:String>
-    <system:String x:Key="SettingsUIChangingChannelTitle" >Changing Release Channels</system:String>
-    <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to change to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
-    <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to change to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to change channels.</system:String>
+    <system:String x:Key="SettingsUIChangingChannelTitle" >Switching Update Channel</system:String>
+    <system:String x:Key="SettingsUIChangeChannelRel" xml:space="preserve">You are about to switch to the Release channel.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to switch channels.</system:String>
+    <system:String x:Key="SettingsUIChangeChannelDev" xml:space="preserve">You are about to switch to the Development channel. This channel may contain untested features and bugs.&#x0a;&#x0a;Are you sure you want to continue? Hedge Mod Manager will need to restart to switch channels.</system:String>
 
     <!-- MainWindow UI Strings -->
     <system:String x:Key="MainUIInstallFormHeader"    >Install a mod by...</system:String>

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -816,31 +816,32 @@ namespace HedgeModManager
             UpdateStatus(Localise("StatusUICheckingForUpdates"));
             try
             {
+                var updateR = await HedgeApp.CheckForUpdatesAsync();
+
+                if (!updateR.Item1 && !ViewModel.DevBuild)
+                {
+                    UpdateStatus(Localise("StatusUINoUpdatesFound"));
+                    return;
+                }
+                else if (updateR.Item1)
+                {
+                    await Dispatcher.InvokeAsync(() => ShowUpdate(updateR.Item2));
+                }
+
                 if (ViewModel.DevBuild)
                 {
-                    var update = await HedgeApp.CheckForUpdatesDevAsync();
+                    var updateD = await HedgeApp.CheckForUpdatesDevAsync();
 
-                    if (!update.Item1)
+                    if (!updateD.Item1)
                     {
                         UpdateStatus(Localise("StatusUINoUpdatesFound"));
                         return;
                     }
 
-                    string changelog = await HedgeApp.GetGitChangeLog(update.Item2.HeadSHA);
-                    await Dispatcher.InvokeAsync(() => ShowUpdate(update.Item2, update.Item3, changelog));
+                    string changelog = await HedgeApp.GetGitChangeLog(updateD.Item2.HeadSHA);
+                    await Dispatcher.InvokeAsync(() => ShowUpdate(updateD.Item2, updateD.Item3, changelog));
                 }
-                else
-                {
-                    var update = await HedgeApp.CheckForUpdatesAsync();
 
-                    if (!update.Item1)
-                    {
-                        UpdateStatus(Localise("StatusUINoUpdatesFound"));
-                        return;
-                    }
-
-                    await Dispatcher.InvokeAsync(() => ShowUpdate(update.Item2));
-                }
                 UpdateStatus(string.Empty);
             }
             catch


### PR DESCRIPTION
Closes #637.

![2023-09-21_15-44-49](https://github.com/thesupersonic16/HedgeModManager/assets/15317421/71ca5506-80bf-4964-935b-2ccbf5700e30)

Clicking Yes will bring up the Release channel update dialogue box, while clicking No will proceed to check for Development channel updates as per usual.

The dialogue box will appear on every boot until either:
- The user updates to a Development build where the build's version matches the current release's version.
- The user switches to the Release channel, in which this check will never occur.

Given that we commit the version increase alongside a new HMM release, we shouldn't run into the issue where a user continuously gets this dialogue box on boot even after updating.

Also updates wording when switching update channels.
![2023-09-21_15-45-00](https://github.com/thesupersonic16/HedgeModManager/assets/15317421/e2a55ff4-ffa2-40fb-a65a-c596ad45d098)