### PR TITLE
Implemented loading multiple code files for mods

### DIFF
--- a/HedgeModManager/ModInfo.cs
+++ b/HedgeModManager/ModInfo.cs
@@ -157,7 +157,7 @@ namespace HedgeModManager
 
                     foreach (var codeFile in CodeFile.Split(','))
                     {
-                        var codesPath = Path.Combine(RootDirectory, codeFile);
+                        var codesPath = Path.Combine(RootDirectory, codeFile.Trim());
                         if (File.Exists(codesPath))
                         {
                             var codes = CodeCompiler.CodeFile.FromFile(codesPath);

--- a/HedgeModManager/ModInfo.cs
+++ b/HedgeModManager/ModInfo.cs
@@ -155,7 +155,7 @@ namespace HedgeModManager
                         ConfigSchema?.LoadValuesFromIni(Path.Combine(RootDirectory, ConfigSchema.IniFile));
                     }
 
-                    foreach (var codeFile in CodeFile.Split(','))
+                    foreach (var codeFile in CodeFile.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         var codesPath = Path.Combine(RootDirectory, codeFile.Trim());
                         if (File.Exists(codesPath))

--- a/HedgeModManager/ModInfo.cs
+++ b/HedgeModManager/ModInfo.cs
@@ -155,14 +155,22 @@ namespace HedgeModManager
                         ConfigSchema?.LoadValuesFromIni(Path.Combine(RootDirectory, ConfigSchema.IniFile));
                     }
 
-                    var codesPath = Path.Combine(RootDirectory, CodeFile);
-                    if (File.Exists(codesPath))
+                    foreach (var codeFile in CodeFile.Split(','))
                     {
-                        Codes = CodeCompiler.CodeFile.FromFile(codesPath);
-                        foreach (var code in Codes.Codes)
+                        var codesPath = Path.Combine(RootDirectory, codeFile);
+                        if (File.Exists(codesPath))
                         {
-                            if (code.IsExecutable())
-                                code.Name = $"{Title}\\{code.Name}";
+                            var codes = CodeCompiler.CodeFile.FromFile(codesPath);
+                            foreach (var code in codes.Codes)
+                            {
+                                if (code.IsExecutable())
+                                    code.Name = $"{Title}\\{code.Name}";
+                            }
+
+                            if (Codes == null)
+                                Codes = codes;
+                            else
+                                Codes.Codes.AddRange(codes.Codes);
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds the ability to compile multiple code files in a single mod.

The `CodeFile` field now takes in comma-separated values, much like the `DLLFile` field.

For example, entering `CodeFile1.hmm,CodeFile2.hmm` into the `CodeFile` field will load those respective files from the mod directory into the code compiler.

Comma separation of varying types are supported, whether there are trailing or leading whitespaces around each comma.