### PR TITLE
macOS Fixes

### DIFF
--- a/HedgeModManager/Events.cs
+++ b/HedgeModManager/Events.cs
@@ -82,6 +82,8 @@ namespace HedgeModManager
                     title += $" - {mainWindow.SelectedModProfile?.Name}";
                 if (HedgeApp.IsLinux)
                     title += " (Linux)";
+                if (HedgeApp.IsMacOS)
+                    title += " (macOS)";
                 mainWindow.Title = title;
             }
         }

--- a/HedgeModManager/HedgeApp.xaml.cs
+++ b/HedgeModManager/HedgeApp.xaml.cs
@@ -73,6 +73,7 @@ namespace HedgeModManager
         public static NetworkConfig NetworkConfiguration = new Singleton<NetworkConfig>(new NetworkConfig());
         public static List<ModProfile> ModProfiles = new List<ModProfile>();
         public static bool IsLinux = false;
+        public static bool IsMacOS = false;
 
         public static HttpClient HttpClient { get; private set; }
         public static string UserAgent { get; }
@@ -115,12 +116,23 @@ namespace HedgeModManager
             Singleton.SetInstance(HttpClient);
             Singleton.SetInstance<IWindowService>(new WindowServiceImplWindows());
 
-            // Check for Wine, assuming Linux
+            // Check for Wine
             RegistryKey key = null;
             if ((key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default).OpenSubKey("SOFTWARE\\Wine")) != null)
             {
                 key.Close();
-                IsLinux = true;
+
+                if ((key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default).OpenSubKey("SOFTWARE\\Wine\\Mac Driver")) != null)
+                {
+                    key.Close();
+
+                    IsMacOS = true;
+                }
+                else
+                {
+                    IsLinux = true;
+                }
+
             }
 
 
@@ -189,7 +201,7 @@ namespace HedgeModManager
             if (CurrentCulture != null)
                 LoadLanguage(CurrentCulture.FileName);
             CountLanguages();
-            if (IsLinux)
+            if (IsLinux || IsMacOS)
                 Linux.PatchHMMRegistry();
 #if DEBUG
             // Find a Steam Game

--- a/HedgeModManager/Steam.cs
+++ b/HedgeModManager/Steam.cs
@@ -17,7 +17,6 @@ namespace HedgeModManager
 
         public static void Init()
         {
-            // Not sure about OSX
             // Assume Steam is located in the home folder for Linux
             if (HedgeApp.IsLinux)
             {

--- a/HedgeModManager/UI/Converters.cs
+++ b/HedgeModManager/UI/Converters.cs
@@ -65,8 +65,8 @@ namespace HedgeModManager
         
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            // HTML rendering currently does not work on Linux
-            if (HedgeApp.IsLinux)
+            // HTML rendering currently does not work on Linux & Mac
+            if (HedgeApp.IsLinux || HedgeApp.IsMacOS)
                 return string.Empty;
 
             string md = value?.ToString();

--- a/HedgeModManager/UI/GBModWindow.xaml.cs
+++ b/HedgeModManager/UI/GBModWindow.xaml.cs
@@ -289,7 +289,7 @@ namespace HedgeModManager.UI
                 Imagebar.Children.Add(button);
             }
 
-            if (HedgeApp.IsLinux)
+            if (HedgeApp.IsLinux || HedgeApp.IsMacOS)
             {
                 Description.Text = string.Empty;
                 Description.Visibility = Visibility.Collapsed;

--- a/HedgeModManager/UI/MainWindow.xaml.cs
+++ b/HedgeModManager/UI/MainWindow.xaml.cs
@@ -424,7 +424,7 @@ namespace HedgeModManager
                 };
                 DataContext = ViewModel;
 
-                Title = $"{HedgeApp.ProgramName} ({HedgeApp.VersionString})" + (HedgeApp.IsLinux ? " (Linux)" : "");
+                Title = $"{HedgeApp.ProgramName} ({HedgeApp.VersionString})" + (HedgeApp.IsLinux ? " (Linux)" : "") + (HedgeApp.IsMacOS ? " (macOS)" : "");
 
                 MainTabControl.SelectedItem = SettingsTab;
                 ComboBox_GameStatus.SelectedValue = HedgeApp.GameInstalls.FirstOrDefault();


### PR DESCRIPTION
Detects macOS Wine using the registry. This likely won't make it work properly on macOS yet, but it will fix the most egregious problem, which is HMM trying to use `xdg-open` on macOS, which obviously won't work.

Steam will be running in Wine here, not native using Proton, so Windows-style launching and detection behaviour should be used.