### PR TITLE
Mitigate TypeInitializationException via ILMerge

### DIFF
--- a/HedgeModManager/FodyWeavers.xml
+++ b/HedgeModManager/FodyWeavers.xml
@@ -1,4 +1,5 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
   <PropertyChanged />
+  <ILMerge />
+  <Costura />
 </Weavers>

--- a/HedgeModManager/FodyWeavers.xsd
+++ b/HedgeModManager/FodyWeavers.xsd
@@ -53,6 +53,92 @@
             </xs:attribute>
           </xs:complexType>
         </xs:element>
+        <xs:element name="ILMerge" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="IncludeAssemblies" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A regular expression matching the assembly names to include in merging.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="ExcludeAssemblies" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A regular expression matching the assembly names to exclude from merging.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="IncludeResources" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A regular expression matching the resource names to include in merging.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="ExcludeResources" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A regular expression matching the resource names to exclude from merging.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="HideImportedTypes" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A switch to control whether the imported types are hidden (made private) or keep their visibility unchanged. Default is 'true'</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="NamespacePrefix" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A string that is used as prefix for the namespace of the imported types.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="FullImport" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A switch to control whether to import the full assemblies or only the referenced types. Default is 'false'</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="CompactMode" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>A switch to enable compacting of the target assembly by skipping properties, events and unused methods. Default is 'false'</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:all>
+            <xs:attribute name="IncludeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A regular expression matching the assembly names to include in merging.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ExcludeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A regular expression matching the assembly names to exclude from merging.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeResources" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A regular expression matching the resource names to include in merging.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ExcludeResources" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A regular expression matching the resource names to exclude from merging.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="HideImportedTypes" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>A switch to control whether the imported types are hidden (made private) or keep their visibility unchanged. Default is 'true'</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="NamespacePrefix" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A string that is used as prefix for the namespace of the imported types.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="FullImport" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>A switch to control whether to import the full assemblies or only the referenced types. Default is 'false'</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="CompactMode" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>A switch to enable compacting of the target assembly by skipping properties, events and unused methods. Default is 'false'</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="Costura" minOccurs="0" maxOccurs="1">
           <xs:complexType>
             <xs:all>

--- a/HedgeModManager/HedgeModManager.csproj
+++ b/HedgeModManager/HedgeModManager.csproj
@@ -87,6 +87,9 @@
       <Version>2.3.2</Version>
     </PackageReference>
     <PackageReference Include="HedgeModManager.CodeCompiler" Version="0.2.114" />
+      <PackageReference Include="ILMerge.Fody" Version="1.24.0">
+          <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
     <PackageReference Include="Markdig">
       <Version>0.25.0</Version>
     </PackageReference>

--- a/HedgeModManager/Properties/AssemblyInfo.cs
+++ b/HedgeModManager/Properties/AssemblyInfo.cs
@@ -4,6 +4,12 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+// Exclude bad IL merges
+// System Libraries
+// WPF Libraries, WPF references break with ILMerge
+// Mono.Cecil errors because I have no idea
+[assembly: ILMerge.ExcludeAssemblies(@"Mono.*|System.*|Microsoft.*|GongSolutions.WPF.DragDrop|PropertyTools.Wpf|HtmlRenderer\.WPF")]
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.


### PR DESCRIPTION
Mitigates crashes related to TypeInitializationException.

The entire program should be tested as ILMerge this late into development is very unpredictable.